### PR TITLE
Change if statement for rooftops

### DIFF
--- a/teaser/logic/buildingobjects/thermalzone.py
+++ b/teaser/logic/buildingobjects/thermalzone.py
@@ -371,7 +371,7 @@ class ThermalZone(object):
         if self.r_conv_inner_rt != 0:
             self.r_conv_inner_ow = 1/((1/self.r_conv_inner_ow)+(
                 1/self.r_conv_inner_rt))
-        if self.r_rad_inner_gf != 0:
+        if self.r_rad_inner_rt != 0:
             self.r_rad_inner_ow = 1/((1/self.r_rad_inner_ow)+(
                 1/self.r_rad_inner_rt))
 


### PR DESCRIPTION
This is just a minor bugfix, as it will only occur if no rooftop is defined