### PR TITLE
Set self.sum_heat_load to zero (building.py / Building object) to pre…

### DIFF
--- a/teaser/logic/buildingobjects/building.py
+++ b/teaser/logic/buildingobjects/building.py
@@ -494,10 +494,12 @@ class Building(object):
             Default: EPS035
         """
 
+        #  Set self.sum_heat_load to zero to prevent summing up of old and new
+        #  design heat load calculation values (see #518)
+        self.sum_heat_load = 0
+
         if year_of_retrofit is not None:
             self.year_of_retrofit = year_of_retrofit
-        else:
-            pass
 
         for zone in self.thermal_zones:
             zone.retrofit_zone(window_type, material)


### PR DESCRIPTION
Bugfix for #518. Sets sum_heat_load attribute to zero before retrofit of building.
Closes #518

