### PR TITLE
updates version number of AixLib to current version

### DIFF
--- a/teaser/logic/buildingobjects/calculation/ibpsa.py
+++ b/teaser/logic/buildingobjects/calculation/ibpsa.py
@@ -44,7 +44,7 @@ class IBPSA(object):
 
         self.parent = parent
         self.file_internal_gains = "InternalGains_" + self.parent.name + ".mat"
-        self.version = {'AixLib': '0.5.2', 'Buildings': '5.1.0',
+        self.version = {'AixLib': '0.6.0', 'Buildings': '5.1.0',
                         'BuildingSystems': '2.0.0-beta2', 'IDEAS': '1.0.0'}
         self.consider_heat_capacity = True
 


### PR DESCRIPTION
This closes #528.
Version number of AixLib is raised to match the latest release https://github.com/RWTH-EBC/AixLib/releases/tag/v0.6.0
