### PR TITLE
Issue559 windowlayout

### DIFF
--- a/teaser/logic/archetypebuildings/bmvbs/office.py
+++ b/teaser/logic/archetypebuildings/bmvbs/office.py
@@ -82,8 +82,10 @@ class Office(NonResidential):
             2: elongated 2 floors
             3: compact (e.g. for a square base building)
     window_layout : int
-        Structure of the window facade type, default is 1, which is
-        representative for a punctuated facade.
+        Structure of the window facade type, default is 0, which is a generic facade
+        representing a statistical mean value of window area. This is the foundation
+        for calculating the other window layouts with correction factors.
+            0: generic facade
             1: punctuated facade (individual windows)
             2: banner facade (continuous windows)
             3: full glazing


### PR DESCRIPTION
This solves #559. It's only an improvement of documentation, now correctly stating that the default for `window_layout` is 0 (not 1). The default value is still 0.
