### PR TITLE
Switch from facade area estimation to calculation

### DIFF
--- a/teaser/data/input/citygml_input.py
+++ b/teaser/data/input/citygml_input.py
@@ -81,7 +81,8 @@ def load_gml(path, prj):
                 elif city_object.Feature.function[0].value() == "1120":
                     bld = Office(
                         parent=prj,
-                        name=city_object.Feature.id)
+                        name=city_object.Feature.id,
+                        office_layout=None)
                 else:
                     bld = Building(
                         parent=prj,

--- a/teaser/data/input/teaserxml_input.py
+++ b/teaser/data/input/teaserxml_input.py
@@ -101,7 +101,7 @@ def _load_building(prj, pyxb_bld, type, project_bind):
         bldg = Building(prj)
 
     elif type == "Office":
-        bldg = Office(prj)
+        bldg = Office(prj, office_layout=None)
 
     elif type == "Institute":
 

--- a/teaser/logic/archetypebuildings/bmvbs/office.py
+++ b/teaser/logic/archetypebuildings/bmvbs/office.py
@@ -219,7 +219,7 @@ class Office(NonResidential):
         self._est_win_area = 0
         self._est_roof_area = 0
         self._est_floor_area = 0
-        self._est_facade_area = 0
+        self._facade_area = 0
         self._est_width = 0
         self._est_length = 0
 
@@ -309,14 +309,20 @@ class Office(NonResidential):
         # manipulation of wall according to facade design
         # (received from window_layout)
 
-        self._est_facade_area = self._est_outer_wall_area + self._est_win_area
+        self._facade_area = self.height_of_floors * self.number_of_floors * (
+                    2 * self._est_width + 2 * self._est_length)
 
-        if not self.window_layout == 0:
-            self._est_outer_wall_area = self._est_facade_area * \
-                self.corr_factor_wall
-            self._est_win_area = self._est_facade_area * self.corr_factor_win
-        else:
-            pass
+        if self.window_layout == 0:
+            self.corr_factor_wall = self._est_outer_wall_area / (
+                    self._est_outer_wall_area + self._est_win_area
+            )
+            self.corr_factor_win = self._est_win_area / (
+                    self._est_outer_wall_area + self._est_win_area
+            )
+        self._est_outer_wall_area = self._facade_area * \
+            self.corr_factor_wall
+        self._est_win_area = self._facade_area * self.corr_factor_win
+
 
         # set the facade area to the four orientations
 

--- a/teaser/logic/archetypebuildings/bmvbs/office.py
+++ b/teaser/logic/archetypebuildings/bmvbs/office.py
@@ -310,14 +310,15 @@ class Office(NonResidential):
         # (received from window_layout)
 
         self._facade_area = self.height_of_floors * self.number_of_floors * (
-                    2 * self._est_width + 2 * self._est_length)
+            2 * self._est_width + 2 * self._est_length
+        )
 
         if self.window_layout == 0:
             self.corr_factor_wall = self._est_outer_wall_area / (
-                    self._est_outer_wall_area + self._est_win_area
+                self._est_outer_wall_area + self._est_win_area
             )
             self.corr_factor_win = self._est_win_area / (
-                    self._est_outer_wall_area + self._est_win_area
+                self._est_outer_wall_area + self._est_win_area
             )
         self._est_outer_wall_area = self._facade_area * \
             self.corr_factor_wall

--- a/teaser/logic/archetypebuildings/bmvbs/office.py
+++ b/teaser/logic/archetypebuildings/bmvbs/office.py
@@ -323,7 +323,6 @@ class Office(NonResidential):
             self.corr_factor_wall
         self._est_win_area = self._facade_area * self.corr_factor_win
 
-
         # set the facade area to the four orientations
 
         for key, value in self.outer_wall_names.items():

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -264,7 +264,7 @@ class Project(object):
             height_of_floors,
             net_leased_area,
             with_ahu=True,
-            office_layout=None,
+            office_layout=3,
             window_layout=None,
             construction_type=None):
         """Add a non-residential building to the TEASER project.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -170,14 +170,14 @@ class Test_teaser(object):
 
         assert round(test_office.get_outer_wall_area(-2), 0) == 958
         assert round(test_office.get_outer_wall_area(-1), 0) == 958
-        assert round(test_office.get_outer_wall_area(0), 0) == 437
-        assert round(test_office.get_outer_wall_area(180), 0) == 437
-        assert round(test_office.get_outer_wall_area(90), 0) == 77
-        assert round(test_office.get_outer_wall_area(270), 0) == 77
-        assert round(test_office.get_window_area(0), 0) == 158
-        assert round(test_office.get_window_area(180), 0) == 158
-        assert round(test_office.get_window_area(90), 0) == 28
-        assert round(test_office.get_window_area(270), 0) == 28
+        assert round(test_office.get_outer_wall_area(0), 0) == 488
+        assert round(test_office.get_outer_wall_area(180), 0) == 488
+        assert round(test_office.get_outer_wall_area(90), 0) == 86
+        assert round(test_office.get_outer_wall_area(270), 0) == 86
+        assert round(test_office.get_window_area(0), 0) == 176
+        assert round(test_office.get_window_area(180), 0) == 176
+        assert round(test_office.get_window_area(90), 0) == 31
+        assert round(test_office.get_window_area(270), 0) == 31
 
         prj.set_default()
         test_office = Office(parent=prj,
@@ -196,14 +196,14 @@ class Test_teaser(object):
 
         assert round(test_office.get_outer_wall_area(-2), 0) == 958
         assert round(test_office.get_outer_wall_area(-1), 0) == 958
-        assert round(test_office.get_outer_wall_area(0), 0) == 446
-        assert round(test_office.get_outer_wall_area(180), 0) == 446
-        assert round(test_office.get_outer_wall_area(90), 0) == 79
-        assert round(test_office.get_outer_wall_area(270), 0) == 79
-        assert round(test_office.get_window_area(0), 0) == 149
-        assert round(test_office.get_window_area(180), 0) == 149
-        assert round(test_office.get_window_area(90), 0) == 26
-        assert round(test_office.get_window_area(270), 0) == 26
+        assert round(test_office.get_outer_wall_area(0), 0) == 498
+        assert round(test_office.get_outer_wall_area(180), 0) == 498
+        assert round(test_office.get_outer_wall_area(90), 0) == 88
+        assert round(test_office.get_outer_wall_area(270), 0) == 88
+        assert round(test_office.get_window_area(0), 0) == 166
+        assert round(test_office.get_window_area(180), 0) == 166
+        assert round(test_office.get_window_area(90), 0) == 29
+        assert round(test_office.get_window_area(270), 0) == 29
 
         prj.set_default()
         test_office = Office(parent=prj,
@@ -222,14 +222,14 @@ class Test_teaser(object):
 
         assert round(test_office.get_outer_wall_area(-2), 0) == 958
         assert round(test_office.get_outer_wall_area(-1), 0) == 958
-        assert round(test_office.get_outer_wall_area(0), 0) == 283
-        assert round(test_office.get_outer_wall_area(180), 0) == 283
-        assert round(test_office.get_outer_wall_area(90), 0) == 67
-        assert round(test_office.get_outer_wall_area(270), 0) == 67
-        assert round(test_office.get_window_area(0), 0) == 283
-        assert round(test_office.get_window_area(180), 0) == 283
-        assert round(test_office.get_window_area(90), 0) == 67
-        assert round(test_office.get_window_area(270), 0) == 67
+        assert round(test_office.get_outer_wall_area(0), 0) == 288
+        assert round(test_office.get_outer_wall_area(180), 0) == 288
+        assert round(test_office.get_outer_wall_area(90), 0) == 68
+        assert round(test_office.get_outer_wall_area(270), 0) == 68
+        assert round(test_office.get_window_area(0), 0) == 288
+        assert round(test_office.get_window_area(180), 0) == 288
+        assert round(test_office.get_window_area(90), 0) == 68
+        assert round(test_office.get_window_area(270), 0) == 68
 
         prj.set_default()
         test_office = Office(parent=prj,
@@ -248,14 +248,14 @@ class Test_teaser(object):
 
         assert round(test_office.get_outer_wall_area(-2), 0) == 958
         assert round(test_office.get_outer_wall_area(-1), 0) == 958
-        assert round(test_office.get_outer_wall_area(0), 0) == 35
-        assert round(test_office.get_outer_wall_area(180), 0) == 35
-        assert round(test_office.get_outer_wall_area(90), 0) == 35
-        assert round(test_office.get_outer_wall_area(270), 0) == 35
-        assert round(test_office.get_window_area(0), 0) == 315
-        assert round(test_office.get_window_area(180), 0) == 315
-        assert round(test_office.get_window_area(90), 0) == 315
-        assert round(test_office.get_window_area(270), 0) == 315
+        assert round(test_office.get_outer_wall_area(0), 0) == 28
+        assert round(test_office.get_outer_wall_area(180), 0) == 28
+        assert round(test_office.get_outer_wall_area(90), 0) == 28
+        assert round(test_office.get_outer_wall_area(270), 0) == 28
+        assert round(test_office.get_window_area(0), 0) == 251
+        assert round(test_office.get_window_area(180), 0) == 251
+        assert round(test_office.get_window_area(90), 0) == 251
+        assert round(test_office.get_window_area(270), 0) == 251
 
     def test_type_bldg_institute4_with_calc(self):
         """
@@ -304,14 +304,14 @@ class Test_teaser(object):
 
         assert round(test_institute4.get_outer_wall_area(-2), 0) == 958
         assert round(test_institute4.get_outer_wall_area(-1), 0) == 958
-        assert round(test_institute4.get_outer_wall_area(0), 0) == 742
-        assert round(test_institute4.get_outer_wall_area(180), 0) == 742
-        assert round(test_institute4.get_outer_wall_area(90), 0) == 131
-        assert round(test_institute4.get_outer_wall_area(270), 0) == 131
-        assert round(test_institute4.get_window_area(0), 0) == 158
-        assert round(test_institute4.get_window_area(180), 0) == 158
-        assert round(test_institute4.get_window_area(90), 0) == 28
-        assert round(test_institute4.get_window_area(270), 0) == 28
+        assert round(test_institute4.get_outer_wall_area(0), 0) == 547
+        assert round(test_institute4.get_outer_wall_area(180), 0) == 547
+        assert round(test_institute4.get_outer_wall_area(90), 0) == 96
+        assert round(test_institute4.get_outer_wall_area(270), 0) == 96
+        assert round(test_institute4.get_window_area(0), 0) == 116
+        assert round(test_institute4.get_window_area(180), 0) == 116
+        assert round(test_institute4.get_window_area(90), 0) == 21
+        assert round(test_institute4.get_window_area(270), 0) == 21
 
     def test_type_bldg_institute8_with_calc(self):
         """
@@ -360,14 +360,14 @@ class Test_teaser(object):
 
         assert round(test_institute8.get_outer_wall_area(-2), 0) == 958
         assert round(test_institute8.get_outer_wall_area(-1), 0) == 958
-        assert round(test_institute8.get_outer_wall_area(0), 0) == 742
-        assert round(test_institute8.get_outer_wall_area(180), 0) == 742
-        assert round(test_institute8.get_outer_wall_area(90), 0) == 131
-        assert round(test_institute8.get_outer_wall_area(270), 0) == 131
-        assert round(test_institute8.get_window_area(0), 0) == 158
-        assert round(test_institute8.get_window_area(180), 0) == 158
-        assert round(test_institute8.get_window_area(90), 0) == 28
-        assert round(test_institute8.get_window_area(270), 0) == 28
+        assert round(test_institute8.get_outer_wall_area(0), 0) == 547
+        assert round(test_institute8.get_outer_wall_area(180), 0) == 547
+        assert round(test_institute8.get_outer_wall_area(90), 0) == 96
+        assert round(test_institute8.get_outer_wall_area(270), 0) == 96
+        assert round(test_institute8.get_window_area(0), 0) == 116
+        assert round(test_institute8.get_window_area(180), 0) == 116
+        assert round(test_institute8.get_window_area(90), 0) == 21
+        assert round(test_institute8.get_window_area(270), 0) == 21
 
     def test_type_bldg_institute_with_calc(self):
         """
@@ -416,14 +416,14 @@ class Test_teaser(object):
 
         assert round(test_institute.get_outer_wall_area(-2), 0) == 958
         assert round(test_institute.get_outer_wall_area(-1), 0) == 958
-        assert round(test_institute.get_outer_wall_area(0), 0) == 836
-        assert round(test_institute.get_outer_wall_area(180), 0) == 836
-        assert round(test_institute.get_outer_wall_area(90), 0) == 147
-        assert round(test_institute.get_outer_wall_area(270), 0) == 147
-        assert round(test_institute.get_window_area(0), 0) == 158
-        assert round(test_institute.get_window_area(180), 0) == 158
-        assert round(test_institute.get_window_area(90), 0) == 28
-        assert round(test_institute.get_window_area(270), 0) == 28
+        assert round(test_institute.get_outer_wall_area(0), 0) == 558
+        assert round(test_institute.get_outer_wall_area(180), 0) == 558
+        assert round(test_institute.get_outer_wall_area(90), 0) == 98
+        assert round(test_institute.get_outer_wall_area(270), 0) == 98
+        assert round(test_institute.get_window_area(0), 0) == 105
+        assert round(test_institute.get_window_area(180), 0) == 105
+        assert round(test_institute.get_window_area(90), 0) == 19
+        assert round(test_institute.get_window_area(270), 0) == 19
 
     def test_type_bldg_residential_with_calc(self):
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -170,14 +170,14 @@ class Test_teaser(object):
 
         assert round(test_office.get_outer_wall_area(-2), 0) == 958
         assert round(test_office.get_outer_wall_area(-1), 0) == 958
-        assert round(test_office.get_outer_wall_area(0), 0) == 488
-        assert round(test_office.get_outer_wall_area(180), 0) == 488
-        assert round(test_office.get_outer_wall_area(90), 0) == 86
-        assert round(test_office.get_outer_wall_area(270), 0) == 86
-        assert round(test_office.get_window_area(0), 0) == 176
-        assert round(test_office.get_window_area(180), 0) == 176
-        assert round(test_office.get_window_area(90), 0) == 31
-        assert round(test_office.get_window_area(270), 0) == 31
+        assert round(test_office.get_outer_wall_area(0), 0) == 205
+        assert round(test_office.get_outer_wall_area(180), 0) == 205
+        assert round(test_office.get_outer_wall_area(90), 0) == 205
+        assert round(test_office.get_outer_wall_area(270), 0) == 205
+        assert round(test_office.get_window_area(0), 0) == 74
+        assert round(test_office.get_window_area(180), 0) == 74
+        assert round(test_office.get_window_area(90), 0) == 74
+        assert round(test_office.get_window_area(270), 0) == 74
 
         prj.set_default()
         test_office = Office(parent=prj,
@@ -272,7 +272,7 @@ class Test_teaser(object):
                                      number_of_floors=3,
                                      height_of_floors=3,
                                      net_leased_area=2500,
-                                     office_layout=0,
+                                     office_layout=None,
                                      window_layout=0,
                                      construction_type="heavy")
 
@@ -304,14 +304,14 @@ class Test_teaser(object):
 
         assert round(test_institute4.get_outer_wall_area(-2), 0) == 958
         assert round(test_institute4.get_outer_wall_area(-1), 0) == 958
-        assert round(test_institute4.get_outer_wall_area(0), 0) == 547
-        assert round(test_institute4.get_outer_wall_area(180), 0) == 547
-        assert round(test_institute4.get_outer_wall_area(90), 0) == 96
-        assert round(test_institute4.get_outer_wall_area(270), 0) == 96
-        assert round(test_institute4.get_window_area(0), 0) == 116
-        assert round(test_institute4.get_window_area(180), 0) == 116
-        assert round(test_institute4.get_window_area(90), 0) == 21
-        assert round(test_institute4.get_window_area(270), 0) == 21
+        assert round(test_institute4.get_outer_wall_area(0), 0) == 436
+        assert round(test_institute4.get_outer_wall_area(180), 0) == 436
+        assert round(test_institute4.get_outer_wall_area(90), 0) == 436
+        assert round(test_institute4.get_outer_wall_area(270), 0) == 436
+        assert round(test_institute4.get_window_area(0), 0) == 93
+        assert round(test_institute4.get_window_area(180), 0) == 93
+        assert round(test_institute4.get_window_area(90), 0) == 93
+        assert round(test_institute4.get_window_area(270), 0) == 93
 
     def test_type_bldg_institute8_with_calc(self):
         """
@@ -328,7 +328,7 @@ class Test_teaser(object):
                                      number_of_floors=3,
                                      height_of_floors=3,
                                      net_leased_area=2500,
-                                     office_layout=0,
+                                     office_layout=None,
                                      window_layout=0,
                                      construction_type="heavy")
 
@@ -360,14 +360,14 @@ class Test_teaser(object):
 
         assert round(test_institute8.get_outer_wall_area(-2), 0) == 958
         assert round(test_institute8.get_outer_wall_area(-1), 0) == 958
-        assert round(test_institute8.get_outer_wall_area(0), 0) == 547
-        assert round(test_institute8.get_outer_wall_area(180), 0) == 547
-        assert round(test_institute8.get_outer_wall_area(90), 0) == 96
-        assert round(test_institute8.get_outer_wall_area(270), 0) == 96
-        assert round(test_institute8.get_window_area(0), 0) == 116
-        assert round(test_institute8.get_window_area(180), 0) == 116
-        assert round(test_institute8.get_window_area(90), 0) == 21
-        assert round(test_institute8.get_window_area(270), 0) == 21
+        assert round(test_institute8.get_outer_wall_area(0), 0) == 436
+        assert round(test_institute8.get_outer_wall_area(180), 0) == 436
+        assert round(test_institute8.get_outer_wall_area(90), 0) == 436
+        assert round(test_institute8.get_outer_wall_area(270), 0) == 436
+        assert round(test_institute8.get_window_area(0), 0) == 93
+        assert round(test_institute8.get_window_area(180), 0) == 93
+        assert round(test_institute8.get_window_area(90), 0) == 93
+        assert round(test_institute8.get_window_area(270), 0) == 93
 
     def test_type_bldg_institute_with_calc(self):
         """
@@ -384,7 +384,7 @@ class Test_teaser(object):
                                    number_of_floors=3,
                                    height_of_floors=3,
                                    net_leased_area=2500,
-                                   office_layout=0,
+                                   office_layout=None,
                                    window_layout=0,
                                    construction_type="heavy")
 
@@ -416,14 +416,14 @@ class Test_teaser(object):
 
         assert round(test_institute.get_outer_wall_area(-2), 0) == 958
         assert round(test_institute.get_outer_wall_area(-1), 0) == 958
-        assert round(test_institute.get_outer_wall_area(0), 0) == 558
-        assert round(test_institute.get_outer_wall_area(180), 0) == 558
-        assert round(test_institute.get_outer_wall_area(90), 0) == 98
-        assert round(test_institute.get_outer_wall_area(270), 0) == 98
-        assert round(test_institute.get_window_area(0), 0) == 105
-        assert round(test_institute.get_window_area(180), 0) == 105
-        assert round(test_institute.get_window_area(90), 0) == 19
-        assert round(test_institute.get_window_area(270), 0) == 19
+        assert round(test_institute.get_outer_wall_area(0), 0) == 492
+        assert round(test_institute.get_outer_wall_area(180), 0) == 492
+        assert round(test_institute.get_outer_wall_area(90), 0) == 492
+        assert round(test_institute.get_outer_wall_area(270), 0) == 492
+        assert round(test_institute.get_window_area(0), 0) == 93
+        assert round(test_institute.get_window_area(180), 0) == 93
+        assert round(test_institute.get_window_area(90), 0) == 93
+        assert round(test_institute.get_window_area(270), 0) == 93
 
     def test_type_bldg_residential_with_calc(self):
         """
@@ -809,7 +809,7 @@ class Test_teaser(object):
                              number_of_floors=7,
                              height_of_floors=1,
                              net_leased_area=1988,
-                             office_layout=0,
+                             office_layout=None,
                              window_layout=0,
                              construction_type="heavy")
 
@@ -822,7 +822,7 @@ class Test_teaser(object):
             height_of_floors=1,
             net_leased_area=1988,
             with_ahu=False,
-            office_layout=0,
+            office_layout=None,
             window_layout=0,
             construction_type="heavy")
 
@@ -834,7 +834,7 @@ class Test_teaser(object):
                                 number_of_floors=7,
                                 height_of_floors=1,
                                 net_leased_area=1988,
-                                office_layout=0,
+                                office_layout=None,
                                 window_layout=0,
                                 construction_type="heavy")
 
@@ -847,7 +847,7 @@ class Test_teaser(object):
             height_of_floors=1,
             net_leased_area=1988,
             with_ahu=True,
-            office_layout=0,
+            office_layout=None,
             window_layout=0,
             construction_type="heavy")
 
@@ -859,7 +859,7 @@ class Test_teaser(object):
                                  number_of_floors=7,
                                  height_of_floors=1,
                                  net_leased_area=1988,
-                                 office_layout=0,
+                                 office_layout=None,
                                  window_layout=0,
                                  construction_type="heavy")
 
@@ -872,7 +872,7 @@ class Test_teaser(object):
             height_of_floors=1,
             net_leased_area=1988,
             with_ahu=True,
-            office_layout=0,
+            office_layout=None,
             window_layout=0,
             construction_type="heavy")
 
@@ -884,7 +884,7 @@ class Test_teaser(object):
                                  number_of_floors=7,
                                  height_of_floors=1,
                                  net_leased_area=1988,
-                                 office_layout=0,
+                                 office_layout=None,
                                  window_layout=0,
                                  construction_type="heavy")
 
@@ -897,7 +897,7 @@ class Test_teaser(object):
             height_of_floors=1,
             net_leased_area=1988,
             with_ahu=True,
-            office_layout=0,
+            office_layout=None,
             window_layout=0,
             construction_type="heavy")
 


### PR DESCRIPTION
For #569.

This implements moving away from estimating the facade area for office buildings and instead calculating it from the building circumference and height. I think that this better represents the building described by the input data.  In order to continue support for `window_layout = 0`, I kept the original estimation of outer wall and window areas, calculate the share of each and use this to redistribute the new facade area between walls and windows. (Nevertheless, I still (see #559) have doubts about whether `window_layout = 0` is a good default value).

In the changed test results, you can see that this can cause significant changes in calculated outer wall and window area for some setups, with possibly far reaching consequences for calculated heating and cooling demands. That's why I think it would be great if @mlauster @PRemmen  and @MichaMans could agree on whether to merge this as-is or find an alternative way forward.
