### PR TITLE
Fix area calculation by using correct base area

### DIFF
--- a/teaser/logic/archetypebuildings/tabula/de/singlefamilyhouse.py
+++ b/teaser/logic/archetypebuildings/tabula/de/singlefamilyhouse.py
@@ -379,7 +379,7 @@ class SingleFamilyHouse(Residential):
                     outer_wall.orientation = value[1]
                     outer_wall.area = (
                         self.facade_estimation_factors[self.building_age_group]["ow1"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self._outer_wall_names_1)
 
         if self.facade_estimation_factors[self.building_age_group]["ow2"] != 0:
@@ -396,7 +396,7 @@ class SingleFamilyHouse(Residential):
                     outer_wall.orientation = value[1]
                     outer_wall.area = (
                         self.facade_estimation_factors[self.building_age_group]["ow2"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self._outer_wall_names_2)
 
         if self.facade_estimation_factors[self.building_age_group]["win1"] != 0:
@@ -413,7 +413,7 @@ class SingleFamilyHouse(Residential):
                     window.orientation = value[1]
                     window.area = (
                         self.facade_estimation_factors[self.building_age_group]["win1"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.window_names_1)
 
         if self.facade_estimation_factors[self.building_age_group]["win2"] != 0:
@@ -430,7 +430,7 @@ class SingleFamilyHouse(Residential):
                     window.orientation = value[1]
                     window.area = (
                         self.facade_estimation_factors[self.building_age_group]["win2"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.window_names_2)
 
         if self.facade_estimation_factors[self.building_age_group]["gf1"] != 0:
@@ -448,7 +448,7 @@ class SingleFamilyHouse(Residential):
                     gf.orientation = value[1]
                     gf.area = (
                         self.facade_estimation_factors[self.building_age_group]["gf1"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.ground_floor_names_1)
 
         if self.facade_estimation_factors[self.building_age_group]["gf2"] != 0:
@@ -466,7 +466,7 @@ class SingleFamilyHouse(Residential):
                     gf.orientation = value[1]
                     gf.area = (
                         self.facade_estimation_factors[self.building_age_group]["gf2"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.ground_floor_names_2)
 
         if self.facade_estimation_factors[self.building_age_group]["rt1"] != 0:
@@ -484,7 +484,7 @@ class SingleFamilyHouse(Residential):
                     rt.orientation = value[1]
                     rt.area = (
                         self.facade_estimation_factors[self.building_age_group]["rt1"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.roof_names_1)
 
         if self.facade_estimation_factors[self.building_age_group]["rt2"] != 0:
@@ -502,7 +502,7 @@ class SingleFamilyHouse(Residential):
                     rt.orientation = value[1]
                     rt.area = (
                         self.facade_estimation_factors[self.building_age_group]["rt2"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.roof_names_2)
 
         if self.facade_estimation_factors[self.building_age_group]["door"] != 0:
@@ -520,7 +520,7 @@ class SingleFamilyHouse(Residential):
                     door.orientation = value[1]
                     door.area = (
                         self.facade_estimation_factors[self.building_age_group]["door"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.door_names)
 
         for key, value in self.inner_wall_names.items():

--- a/teaser/logic/archetypebuildings/tabula/dk/singlefamilyhouse.py
+++ b/teaser/logic/archetypebuildings/tabula/dk/singlefamilyhouse.py
@@ -346,7 +346,7 @@ class SingleFamilyHouse(Residential):
                     outer_wall.orientation = value[1]
                     outer_wall.area = (
                         self.facade_estimation_factors[self.building_age_group]["ow1"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self._outer_wall_names_1)
 
         if self.facade_estimation_factors[self.building_age_group]["ow2"] != 0:
@@ -363,7 +363,7 @@ class SingleFamilyHouse(Residential):
                     outer_wall.orientation = value[1]
                     outer_wall.area = (
                         self.facade_estimation_factors[self.building_age_group]["ow2"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self._outer_wall_names_2)
 
         if self.facade_estimation_factors[self.building_age_group]["win1"] != 0:
@@ -380,7 +380,7 @@ class SingleFamilyHouse(Residential):
                     window.orientation = value[1]
                     window.area = (
                         self.facade_estimation_factors[self.building_age_group]["win1"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.window_names_1)
 
         if self.facade_estimation_factors[self.building_age_group]["win2"] != 0:
@@ -397,7 +397,7 @@ class SingleFamilyHouse(Residential):
                     window.orientation = value[1]
                     window.area = (
                         self.facade_estimation_factors[self.building_age_group]["win2"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.window_names_2)
 
         if self.facade_estimation_factors[self.building_age_group]["gf1"] != 0:
@@ -415,7 +415,7 @@ class SingleFamilyHouse(Residential):
                     gf.orientation = value[1]
                     gf.area = (
                         self.facade_estimation_factors[self.building_age_group]["gf1"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.ground_floor_names_1)
 
         if self.facade_estimation_factors[self.building_age_group]["gf2"] != 0:
@@ -433,7 +433,7 @@ class SingleFamilyHouse(Residential):
                     gf.orientation = value[1]
                     gf.area = (
                         self.facade_estimation_factors[self.building_age_group]["gf2"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.ground_floor_names_2)
 
         if self.facade_estimation_factors[self.building_age_group]["rt1"] != 0:
@@ -451,7 +451,7 @@ class SingleFamilyHouse(Residential):
                     rt.orientation = value[1]
                     rt.area = (
                         self.facade_estimation_factors[self.building_age_group]["rt1"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.roof_names_1)
 
         if self.facade_estimation_factors[self.building_age_group]["rt2"] != 0:
@@ -469,7 +469,7 @@ class SingleFamilyHouse(Residential):
                     rt.orientation = value[1]
                     rt.area = (
                         self.facade_estimation_factors[self.building_age_group]["rt2"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.roof_names_2)
 
         if self.facade_estimation_factors[self.building_age_group]["door"] != 0:
@@ -487,7 +487,7 @@ class SingleFamilyHouse(Residential):
                     door.orientation = value[1]
                     door.area = (
                         self.facade_estimation_factors[self.building_age_group]["door"]
-                        * type_bldg_area
+                        * zone.area
                     ) / len(self.door_names)
 
         for key, value in self.inner_wall_names.items():


### PR DESCRIPTION
For #662

- Use zone's area instead of the total building area to calculate the correct share of areas for the model for the tabula building archetypes.