### PR TITLE
Issue669 setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             "package_order",
             "conversion",
             "modelica_language",
+            "modelica_test_script",
         ],
         "teaser.data.output.modelicatemplate.AixLib": [
             "AixLib_Multizone",


### PR DESCRIPTION
For #669 : 

We added a new template `modelica_test_script`. This needs to be added to `package_data` in `setup.py`, otherwise the file is missing and TEASER will not work when installed directly from GitHub via pip.
