### PR TITLE
remove not existing webtool from readme

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,7 +4,7 @@ on: push
 jobs:
   build_test_publish:
     name: "Build & Test"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 1
       matrix:

--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ available under the
 If you have any questions regarding TEASER feel free to contact us at
 [ebc-teaser@eonerc.rwth-aachen.de](mailto:ebc-teaser@eonerc.rwth-aachen.de).
 
-If you want to use TEASER without installation, you can use out TEASER webtool, which
-will generate a Modelica model and provide this as download:
-
- * [http://teaser.eonerc.rwth-aachen.de](http://teaser.eonerc.rwth-aachen.de)
 
 ## Description
 


### PR DESCRIPTION
closes #731 by removing the Webtool and it's URL from README.md