### PR TITLE
fix outer area calculation for visualization

### DIFF
--- a/teaser/data/output/reports/model_report.py
+++ b/teaser/data/output/reports/model_report.py
@@ -57,7 +57,7 @@ def create_model_report(prj, path):
         # make sure that lowest values of orient come first
         sorted_keys = sorted(outer_areas.keys())
         sorted_outer_areas = {key: outer_areas[key] for key in sorted_keys}
-        for orient in outer_areas:
+        for orient in sorted_outer_areas:
             # some archetypes use floats, some integers for orientation in
             # TEASER
             orient = float(orient)


### PR DESCRIPTION
Small fix. The prior code lead depending on the structure of the model to wrong assignments of the orientation of the outer wall areas.