### PR TITLE
Add post processing block to multizone template again

### DIFF
--- a/teaser/data/output/modelicatemplate/AixLib/AixLib_Multizone
+++ b/teaser/data/output/modelicatemplate/AixLib/AixLib_Multizone
@@ -117,6 +117,15 @@ AixLib.ThermalZones.ReducedOrder.Multizone.MultizoneEquipped multizone(
       columns=2:${len(bldg.thermal_zones)+1})
       "Set points for cooler"
     annotation (Placement(transformation(extent={{72,-90},{56,-74}})));
+  % if use_postprocessing_calc:
+    AixLib.ThermalZones.ReducedOrder.Multizone.BaseClasses.MultizonePostProcessing
+      multizonePostProcessing(
+      VAir=multizone.VAir,
+      numZones=multizone.numZones,
+      zoneParam=multizone.zoneParam,
+      calc_rel_humidity=multizone.use_moisture_balance)
+      annotation (Placement(transformation(extent={{82,80},{102,100}})));
+  % endif
 
 equation
   connect(weaDat.weaBus, multizone.weaBus) annotation (Line(


### PR DESCRIPTION
This was somehow removed in the latest merges and caused the bim2sim pipelines to fail.