### PR TITLE
771 add besmod export

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Efficient Buildings and Indoor
 Climate](https://www.ebc.eonerc.rwth-aachen.de/cms/~dmzz/E-ON-ERC-EBC/?lidx=1).
 
  * [AixLib](https://github.com/RWTH-EBC/AixLib)
+ * [BESMod](https://github.com/RWTH-EBC/BESMod)
  * [Buildings](https://github.com/lbl-srg/modelica-buildings)
  * [BuildingSystems](https://github.com/UdK-VPT/BuildingSystems)
  * [IDEAS](https://github.com/open-ideas/IDEAS).
@@ -67,7 +68,7 @@ If you just want to read the example on github, check them here: docs/examples.
 
 ### Dependencies
 
-TEASER is currently tested against Python 3.6 and 3.7. Older versions of Python may
+TEASER is currently tested against Python 3.7 up to 3.11. Older versions of Python may
 still work, but are no longer actively supported.
 Using a Python distribution is recommended as they already contain (or easily
 support installation of) many Python packages (e.g. SciPy, NumPy, pip, PyQT,

--- a/docs/jupyter_notebooks/e11_export_besmod_models.ipynb
+++ b/docs/jupyter_notebooks/e11_export_besmod_models.ipynb
@@ -121,7 +121,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": "path = prj.export_besmod(\n    THydSup_nominal=THydSup_nominal,\n    path=save_dir_path,\n    examples=examples\n)\n"
+            "source": "path = prj.export_besmod(\n    THydSup_nominal=THydSup_nominal,\n    path=None,\n    examples=examples\n)\n"
         },
         {
             "cell_type": "markdown",
@@ -157,7 +157,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": "path = prj.export_besmod(\n    THydSup_nominal=THydSup_nominal,\n    QBuiOld_flow_design=QBuiOld_flow_design,\n    path=save_dir_path,\n    examples=examples\n)\n"
+            "source": "path = prj.export_besmod(\n    THydSup_nominal=THydSup_nominal,\n    QBuiOld_flow_design=QBuiOld_flow_design,\n    path=None,\n    examples=examples\n)\n"
         },
         {
             "cell_type": "markdown",
@@ -167,7 +167,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "Custom template\n< %namespace file = \"/modelica_language/\" import=\"get_list\" / >\nwithin ${bldg.parent.name}.${bldg.name};\nmodel ModelicaConferencePaper${bldg.name}\n    extends BESMod.Examples.ModelicaConferencePaper.PartialModelicaConferenceUseCase(\n      redeclare ${bldg.name} building,\n      redeclare BESMod.Systems.UserProfiles.TEASERProfiles\n      userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(\n              \"modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt\"),\n               setBakTSetZone(amplitude=${get_list(setBakTSetZone_amplitude)},\n                              width =${get_list(setBakTSetZone_width)},\n                              startTime =${get_list(setBakTSetZone_startTime)})),\n    systemParameters(nZones=${len(bldg.thermal_zones)},\n                     QBui_flow_nominal = building.QRec_flow_nominal,\n                     TOda_nominal =${TOda_nominal},\n                     TSetZone_nominal =${get_list(TSetZone_nominal)},\n                     THydSup_nominal =${THydSup_nominal},\n                     QBuiOld_flow_design =${QBuiOld_flow_design},\n                     THydSupOld_design =${THydSupOld_design},\n                     filNamWea = Modelica.Utilities.Files.loadResource(\n                          \"modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}\")));\n\n   extends Modelica.Icons.Example;\n\n    annotation(experiment(StopTime=172800,\n                          Interval=600,\n                          Tolerance=1e-06),\n               __Dymola_Commands(file=\n                                 \"Resources/Scripts/Dymola/${bldg.name}/ModelicaConferencePaper${bldg.name}.mos\"\n                                 \"Simulate and plot\"));\nend\nModelicaConferencePaper${bldg.name};\n"
+            "source": "Custom template\n```\n< %namespace file = \"/modelica_language/\" import=\"get_list\" / >\nwithin ${bldg.parent.name}.${bldg.name};\nmodel ModelicaConferencePaper${bldg.name}\n    extends BESMod.Examples.ModelicaConferencePaper.PartialModelicaConferenceUseCase(\n      redeclare ${bldg.name} building,\n      redeclare BESMod.Systems.UserProfiles.TEASERProfiles\n      userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(\n              \"modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt\"),\n               setBakTSetZone(amplitude=${get_list(setBakTSetZone_amplitude)},\n                              width =${get_list(setBakTSetZone_width)},\n                              startTime =${get_list(setBakTSetZone_startTime)})),\n    systemParameters(nZones=${len(bldg.thermal_zones)},\n                     QBui_flow_nominal = building.QRec_flow_nominal,\n                     TOda_nominal =${TOda_nominal},\n                     TSetZone_nominal =${get_list(TSetZone_nominal)},\n                     THydSup_nominal =${THydSup_nominal},\n                     QBuiOld_flow_design =${QBuiOld_flow_design},\n                     THydSupOld_design =${THydSupOld_design},\n                     filNamWea = Modelica.Utilities.Files.loadResource(\n                          \"modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}\")));\n\n   extends Modelica.Icons.Example;\n\n    annotation(experiment(StopTime=172800,\n                          Interval=600,\n                          Tolerance=1e-06),\n               __Dymola_Commands(file=\n                                 \"Resources/Scripts/Dymola/${bldg.name}/ModelicaConferencePaper${bldg.name}.mos\"\n                                 \"Simulate and plot\"));\nend\nModelicaConferencePaper${bldg.name};\n```\n"
         },
         {
             "cell_type": "code",
@@ -186,7 +186,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": "custom_script = {\"HeatPumpMonoenergetic\": os.path.join(custom_template_path, \"custom_script_hp_mono.txt\"),\n                 \"ModelicaConferencePaper\": os.path.join(custom_template_path, \"custom_script.txt\")}\n\npath = prj.export_besmod(\n    THydSup_nominal=THydSup_nominal,\n    path=save_dir_path,\n    examples=examples,\n    custom_examples=custom_example_template,\n    custom_script=custom_script\n)\n"
+            "source": "custom_script = {\"HeatPumpMonoenergetic\": os.path.join(custom_template_path, \"custom_script_hp_mono.txt\"),\n                 \"ModelicaConferencePaper\": os.path.join(custom_template_path, \"custom_script.txt\")}\n\npath = prj.export_besmod(\n    THydSup_nominal=THydSup_nominal,\n    path=None,\n    examples=examples,\n    custom_examples=custom_example_template,\n    custom_script=custom_script\n)\n"
         }
     ],
     "metadata": {

--- a/docs/jupyter_notebooks/e2_export_aixlib_models.ipynb
+++ b/docs/jupyter_notebooks/e2_export_aixlib_models.ipynb
@@ -3,12 +3,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "# Example 2: Export Modelica models for AixLib library using TEASER API\n"
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": "This module contains an example how to export buildings from a TEASER\nproject to ready-to-run simulation models for Modelica library AixLib.\nAixLib focuses on ideal hat demand calculation. In contrast,\nIBPSA focuses on the free floating temperature and has no ideal heater,\nand BESMod on the coupling to state-of-the-art energy systems.\nThese models will only simulate using Dymola, the reason for this are state\nmachines that are used in one AixLib specific AHU model.\nYou can run this example using the [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/main?labpath=docs%2Fjupyter_notebooks)\n"
+            "source": "# Example 2: Export Modelica models for AixLib library using TEASER API\nThis module contains an example how to export buildings from a TEASER\nproject to ready-to-run simulation models for Modelica library AixLib.\nAixLib focuses on ideal hat demand calculation. In contrast,\nIBPSA focuses on the free floating temperature and has no ideal heater,\nand BESMod on the coupling to state-of-the-art energy systems.\nThese models will only simulate using Dymola, the reason for this are state\nmachines that are used in one AixLib specific AHU model.\nYou can run this example using the [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/main?labpath=docs%2Fjupyter_notebooks)\n"
         },
         {
             "cell_type": "code",

--- a/docs/jupyter_notebooks/e3_export_ibpsa_models.ipynb
+++ b/docs/jupyter_notebooks/e3_export_ibpsa_models.ipynb
@@ -3,12 +3,7 @@
         {
             "cell_type": "markdown",
             "metadata": {},
-            "source": "# Example 3: Export Modelica models for IBPSA library using TEASER API\n"
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": "This module contains an example how to export buildings from a TEASER\nproject to ready-to-run simulation models for Modelica library IBPSA.\nIBPSA focuses on free floating temperature without an ideal heater.\nIn contrast, AixLib focuses on ideal heat demand calculation, and\nBESMod on the coupling to state-of-the-art energy systems.\nThese models simulate in Dymola, OpenModelica and JModelica.\nYou can run this example using the [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/main?labpath=docs%2Fjupyter_notebooks)\n"
+            "source": "# Example 3: Export Modelica models for IBPSA library using TEASER API\nThis module contains an example how to export buildings from a TEASER\nproject to ready-to-run simulation models for Modelica library IBPSA.\nIBPSA focuses on free floating temperature without an ideal heater.\nIn contrast, AixLib focuses on ideal heat demand calculation, and\nBESMod on the coupling to state-of-the-art energy systems.\nThese models should simulate in Dymola, OpenModelica and JModelica.\nYou can run this example using the [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/main?labpath=docs%2Fjupyter_notebooks)\n"
         },
         {
             "cell_type": "code",

--- a/docs/jupyter_notebooks/e6_generate_building.ipynb
+++ b/docs/jupyter_notebooks/e6_generate_building.ipynb
@@ -51,7 +51,7 @@
             "execution_count": null,
             "metadata": {},
             "outputs": [],
-            "source": "from teaser.logic.buildingobjects.thermalzone import ThermalZone\n\ntz = ThermalZone(parent=bldg)\ntz.name = \"LivingRoom\"\ntz.area = 140.0\ntz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors\ntz.infiltration_rate = 0.5\n"
+            "source": "from teaser.logic.buildingobjects.thermalzone import ThermalZone\n\ntz = ThermalZone(parent=bldg)\ntz.name = \"LivingRoom\"\ntz.area = 140.0\ntz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors\n"
         },
         {
             "cell_type": "markdown",

--- a/docs/source/examples/e11_export_besmod_models.md
+++ b/docs/source/examples/e11_export_besmod_models.md
@@ -119,7 +119,7 @@ Export all buildings to BESMod and include them in predefined example systems.
 ```python
 path = prj.export_besmod(
     THydSup_nominal=THydSup_nominal,
-    path=save_dir_path,
+    path=None,
     examples=examples
 )
 ```
@@ -160,7 +160,7 @@ THydSupOld_design values, which are used for radiator sizing but not for control
 path = prj.export_besmod(
     THydSup_nominal=THydSup_nominal,
     QBuiOld_flow_design=QBuiOld_flow_design,
-    path=save_dir_path,
+    path=None,
     examples=examples
 )
 ```
@@ -171,6 +171,7 @@ For instance, a custom template is defined here to include the building in the
 ModelicaConferencePaper example from BESMod, which features an integrated battery system.
 
 Custom template
+```
 < %namespace file = "/modelica_language/" import="get_list" / >
 within ${bldg.parent.name}.${bldg.name};
 model ModelicaConferencePaper${bldg.name}
@@ -202,6 +203,7 @@ model ModelicaConferencePaper${bldg.name}
                                  "Simulate and plot"));
 end
 ModelicaConferencePaper${bldg.name};
+```
 
 ```python
 prj.name = "ArchetypeExample_custom"
@@ -224,7 +226,7 @@ custom_script = {"HeatPumpMonoenergetic": os.path.join(custom_template_path, "cu
 
 path = prj.export_besmod(
     THydSup_nominal=THydSup_nominal,
-    path=save_dir_path,
+    path=None,
     examples=examples,
     custom_examples=custom_example_template,
     custom_script=custom_script

--- a/docs/source/examples/e2_export_aixlib_models.md
+++ b/docs/source/examples/e2_export_aixlib_models.md
@@ -1,6 +1,5 @@
 
 # Example 2: Export Modelica models for AixLib library using TEASER API
-
 This module contains an example how to export buildings from a TEASER
 project to ready-to-run simulation models for Modelica library AixLib.
 AixLib focuses on ideal hat demand calculation. In contrast,

--- a/docs/source/examples/e3_export_ibpsa_models.md
+++ b/docs/source/examples/e3_export_ibpsa_models.md
@@ -1,12 +1,11 @@
 
 # Example 3: Export Modelica models for IBPSA library using TEASER API
-
 This module contains an example how to export buildings from a TEASER
 project to ready-to-run simulation models for Modelica library IBPSA.
 IBPSA focuses on free floating temperature without an ideal heater.
 In contrast, AixLib focuses on ideal heat demand calculation, and
 BESMod on the coupling to state-of-the-art energy systems.
-These models simulate in Dymola, OpenModelica and JModelica.
+These models should simulate in Dymola, OpenModelica and JModelica.
 You can run this example using the [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/main?labpath=docs%2Fjupyter_notebooks)
 
 ```python

--- a/docs/source/examples/e6_generate_building.md
+++ b/docs/source/examples/e6_generate_building.md
@@ -54,7 +54,6 @@ tz = ThermalZone(parent=bldg)
 tz.name = "LivingRoom"
 tz.area = 140.0
 tz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors
-tz.infiltration_rate = 0.5
 ```
 
 Instantiate BoundaryConditions and load conditions for `Living`.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "teaser.examples",
         "teaser.examples.verification",
         "teaser.examples.examplefiles",
-    ],  # ToDo fwu-hst: update setup.py
+    ],
     package_data={
         "teaser.data.input.inputdata": ["*.json"],
         "teaser.data.input.inputdata.weatherdata": [

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "teaser.data.output.modelicatemplate",
         "teaser.data.output.reports",
         "teaser.data.output.modelicatemplate.AixLib",
+        "teaser.data.output.modelicatemplate.BESMod",
         "teaser.data.output.modelicatemplate.IBPSA",
         "teaser.examples",
         "teaser.examples.verification",
@@ -72,6 +73,15 @@ setup(
             "AixLib_ThermalZoneRecord_TwoElement",
             "AixLib_ThermalZoneRecord_ThreeElement",
             "AixLib_ThermalZoneRecord_FourElement",
+        ],
+        "teaser.data.output.modelicatemplate.BESMod": [
+            "Building",
+            "Example_GasBoilerBuildingOnly",
+            "Example_HeatPumpMonoenergetic",
+            "Example_TEASERHeatLoadCalculation",
+            "Script_GasBoilerBuildingOnly",
+            "Script_HeatPumpMonoenergetic",
+            "Script_TEASERHeatLoadCalculation",
         ],
         "teaser.data.output.modelicatemplate.IBPSA": [
             "IBPSA_OneElement",

--- a/teaser/__init__.py
+++ b/teaser/__init__.py
@@ -7,7 +7,7 @@ Tool for Energy Analysis and Simulation for Efficient Retrofit
 import sys
 import os
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 
 new_path = os.path.join(os.path.expanduser('~'), ("TEASEROutput"))

--- a/teaser/data/input/inputdata/UseConditions.json
+++ b/teaser/data/input/inputdata/UseConditions.json
@@ -19,7 +19,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -190,7 +190,7 @@
         "maintained_illuminance": 500.0,
         "lighting_efficiency_lumen": 150,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -361,7 +361,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -532,7 +532,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -703,7 +703,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -874,7 +874,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1045,7 +1045,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1216,7 +1216,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1387,7 +1387,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1558,7 +1558,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.5,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1729,7 +1729,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.5,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -1900,7 +1900,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -2071,7 +2071,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -2242,7 +2242,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -2413,7 +2413,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -2584,7 +2584,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -2755,7 +2755,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -2926,7 +2926,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -3097,7 +3097,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -3268,7 +3268,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -3439,7 +3439,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -3610,7 +3610,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -3781,7 +3781,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -3952,7 +3952,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -4121,7 +4121,7 @@
         "fixed_lighting_power": 10.8,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -4292,7 +4292,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -4463,7 +4463,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -4634,7 +4634,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -4805,7 +4805,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -4976,7 +4976,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -5147,7 +5147,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -5318,7 +5318,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -5489,7 +5489,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -5660,7 +5660,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -5831,7 +5831,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -6002,7 +6002,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -6173,7 +6173,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -6344,7 +6344,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -6515,7 +6515,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -6686,7 +6686,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -6857,7 +6857,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -7028,7 +7028,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -7199,7 +7199,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.9,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -7370,7 +7370,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.5,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,
@@ -7541,7 +7541,7 @@
         "lighting_efficiency_lumen": 150,
         "ratio_conv_rad_lighting": 0.5,
         "use_constant_infiltration": false,
-        "infiltration_rate": 0.2,
+        "base_infiltration": 0.2,
         "max_user_infiltration": 1.0,
         "max_overheating_infiltration": [
             3.0,

--- a/teaser/data/input/teaserjson_input.py
+++ b/teaser/data/input/teaserjson_input.py
@@ -196,7 +196,7 @@ def load_teaser_json(path, project):
                 "use_constant_infiltration"
             ]
             tz.use_conditions.base_infiltration = zone_in["use_conditions"][
-                "infiltration_rate"
+                "base_infiltration"
             ]
             tz.use_conditions.max_user_infiltration = zone_in["use_conditions"][
                 "max_user_infiltration"

--- a/teaser/data/input/teaserjson_input.py
+++ b/teaser/data/input/teaserjson_input.py
@@ -196,7 +196,7 @@ def load_teaser_json(path, project):
             tz.use_conditions.use_constant_infiltration = zone_in["use_conditions"][
                 "use_constant_infiltration"
             ]
-            tz.use_conditions.infiltration_rate = zone_in["use_conditions"][
+            tz.use_conditions.base_infiltration = zone_in["use_conditions"][
                 "infiltration_rate"
             ]
             tz.use_conditions.max_user_infiltration = zone_in["use_conditions"][

--- a/teaser/data/input/usecond_input.py
+++ b/teaser/data/input/usecond_input.py
@@ -60,7 +60,7 @@ def load_use_conditions(use_cond, zone_usage, data_class):
         "use_constant_infiltration"
     ]
     use_cond.base_infiltration = conditions_bind[zone_usage][
-        "infiltration_rate"
+        "base_infiltration"
     ]
     use_cond.max_user_infiltration = conditions_bind[zone_usage][
         "max_user_infiltration"

--- a/teaser/data/input/usecond_input.py
+++ b/teaser/data/input/usecond_input.py
@@ -59,7 +59,7 @@ def load_use_conditions(use_cond, zone_usage, data_class):
     use_cond.use_constant_infiltration = conditions_bind[zone_usage][
         "use_constant_infiltration"
     ]
-    use_cond.infiltration_rate = conditions_bind[zone_usage][
+    use_cond.base_infiltration = conditions_bind[zone_usage][
         "infiltration_rate"
     ]
     use_cond.max_user_infiltration = conditions_bind[zone_usage][

--- a/teaser/data/output/aixlib_output.py
+++ b/teaser/data/output/aixlib_output.py
@@ -99,6 +99,10 @@ def export_multizone(
             "data/output/modelicatemplate/modelica_test_script"),
         lookup=lookup)
 
+    dir_resources = utilities.create_path(os.path.join(path, "Resources"))
+    dir_scripts = utilities.create_path(os.path.join(dir_resources, "Scripts"))
+    dir_dymola = utilities.create_path(os.path.join(dir_scripts, "Dymola"))
+
     uses = [
         'Modelica(version="' + prj.modelica_info.version + '")',
         'AixLib(version="' + prj.buildings[-1].library_attr.version + '")']
@@ -164,15 +168,6 @@ def export_multizone(
 
             out_file.close()
 
-        dir_resources = os.path.join(path, "Resources")
-        if not os.path.exists(dir_resources):
-            os.mkdir(dir_resources)
-        dir_scripts = os.path.join(dir_resources, "Scripts")
-        if not os.path.exists(dir_scripts):
-            os.mkdir(dir_scripts)
-        dir_dymola = os.path.join(dir_scripts, "Dymola")
-        if not os.path.exists(dir_dymola):
-            os.mkdir(dir_dymola)
         _help_test_script(bldg, dir_dymola, test_script_template)
 
         zone_path = os.path.join(bldg_path, bldg.name + "_DataBase")

--- a/teaser/data/output/aixlib_output.py
+++ b/teaser/data/output/aixlib_output.py
@@ -6,6 +6,7 @@ import shutil
 from mako.template import Template
 from mako.lookup import TemplateLookup
 import teaser.logic.utilities as utilities
+import teaser.data.output.modelica_output as modelica_output
 
 
 def export_multizone(
@@ -106,17 +107,15 @@ def export_multizone(
     uses = [
         'Modelica(version="' + prj.modelica_info.version + '")',
         'AixLib(version="' + prj.buildings[-1].library_attr.version + '")']
-    _help_package(
+    modelica_output.create_package(
         path=path,
         name=prj.name,
-        uses=uses,
-        within=None)
-    _help_package_order(
+        uses=uses)
+    modelica_output.create_package_order(
         path=path,
         package_list=buildings,
-        addition=None,
         extra=None)
-    _copy_weather_data(prj.weather_file_path, path)
+    modelica_output.copy_weather_data(prj.weather_file_path, path)
 
     for i, bldg in enumerate(buildings):
 
@@ -138,11 +137,10 @@ def export_multizone(
         bldg.library_attr.modelica_gains_boundary(
             path=bldg_path)
 
-        _help_package(path=bldg_path, name=bldg.name, within=bldg.parent.name)
-        _help_package_order(
+        modelica_output.create_package(path=bldg_path, name=bldg.name, within=bldg.parent.name)
+        modelica_output.create_package_order(
             path=bldg_path,
             package_list=[bldg],
-            addition=None,
             extra=[bldg.name + "_DataBase"])
 
         if bldg.building_id is None:
@@ -188,11 +186,11 @@ def export_multizone(
 
                 out_file.close()
 
-        _help_package(
+        modelica_output.create_package(
             path=zone_path,
             name=bldg.name + '_DataBase',
             within=prj.name + '.' + bldg.name)
-        _help_package_order(
+        modelica_output.create_package_order(
             path=zone_path,
             package_list=bldg.thermal_zones,
             addition=bldg.name + "_",
@@ -267,80 +265,6 @@ def _help_test_script(bldg, dir_dymola, test_script_template):
             names_variables=names_variables,
         ))
         out_file.close()
-
-
-def _help_package(path, name, uses=None, within=None):
-    """creates a package.mo file
-
-    private function, do not call
-
-    Parameters
-    ----------
-
-    path : string
-        path of where the package.mo should be placed
-    name : string
-        name of the Modelica package
-    within : string
-        path of Modelica package containing this package
-
-    """
-
-    package_template = Template(filename=utilities.get_full_path(
-        "data/output/modelicatemplate/package"))
-    with open(utilities.get_full_path(os.path.join(
-            path, "package.mo")), 'w') as out_file:
-
-        out_file.write(package_template.render_unicode(
-            name=name,
-            within=within,
-            uses=uses))
-        out_file.close()
-
-
-def _help_package_order(path, package_list, addition=None, extra=None):
-    """creates a package.order file
-
-    private function, do not call
-
-    Parameters
-    ----------
-
-    path : string
-        path of where the package.order should be placed
-    package_list : [buildings or thermal_zones]
-        objects with the attribute name of all models or packages contained in the package
-    addition : string
-        if there should be a prefix of package_list.string it can
-        be specified
-    extra : [string]
-        list of extra packages or models not contained in package_list can be
-        specified
-
-    """
-
-    order_template = Template(filename=utilities.get_full_path(
-        "data/output/modelicatemplate/package_order"))
-    with open(utilities.get_full_path(
-            path + "/" + "package" + ".order"), 'w') as out_file:
-
-        out_file.write(order_template.render_unicode
-                       (list=package_list, addition=addition, extra=extra))
-        out_file.close()
-
-
-def _copy_weather_data(source_path, destination_path):
-    """Copies the imported .mos weather file to the results folder.
-
-    Parameters
-    ----------
-    source_path : str
-        path of local weather file
-    destination_path : str
-        path of where the weather file should be placed
-    """
-
-    shutil.copy2(source_path, destination_path)
 
 
 def _copy_script_unit_tests(destination_path):

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -13,6 +13,7 @@ def export_besmod(
         path=None,
         examples=None,
         THydSup_nominal=None,
+        TSetZone_nominal=293.15,
         QBuiOld_flow_design=None,
         THydSupOld_design=None,
         custom_examples=None,
@@ -40,6 +41,9 @@ def export_besmod(
     THydSup_nominal : float or dict, optional
         Nominal supply temperature(s) for the hydraulic system. Required for
         certain examples (e.g., HeatPumpMonoenergetic, GasBoilerBuildingOnly).
+        See docstring of teaser.data.output.besmod_output.convert_input() for further information.
+    TSetZone_nominal : float or dict, optional
+        Nominal set temperature(s) for the thermal zones.
         See docstring of teaser.data.output.besmod_output.convert_input() for further information.
     QBuiOld_flow_design : dict, optional
         For partially retrofitted systems specify the old nominal heat flow
@@ -91,6 +95,7 @@ def export_besmod(
                          "require the `THydSup_nominal` parameter.")
 
     t_hyd_sup_nominal_bldg = convert_input(THydSup_nominal, buildings)
+    t_set_zone_nominal_bldg = convert_input(TSetZone_nominal, buildings)
     t_hyd_sup_old_design_bldg = convert_input(THydSupOld_design, buildings) if THydSupOld_design else \
         {bldg.name: "systemParameters.THydSup_nominal" for bldg in buildings}
 
@@ -163,6 +168,7 @@ def export_besmod(
                     project=prj,
                     TOda_nominal=bldg.thermal_zones[0].t_outside,
                     THydSup_nominal=t_hyd_sup_nominal_bldg[bldg.name],
+                    TSetZone_nominal=t_set_zone_nominal_bldg[bldg.name],
                     QBuiOld_flow_design=QBuiOld_flow_design[bldg.name],
                     THydSupOld_design=t_hyd_sup_old_design_bldg[bldg.name],
                     startTimeSetBack=start_time_set_back,

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -15,7 +15,6 @@ def export_besmod(
         path=None,
         examples=None,
         THydSup_nominal=None,
-        TOda_nominal=262.65,
         QBuiOld_flow_design=None,
         THydSupOld_design=None):
     """Exports buildings for BESMod simulation
@@ -37,8 +36,6 @@ def export_besmod(
     prj : instance of Project
         Instance of TEASER Project object to access Project related
         information, e.g. name or version of used libraries
-    TOda_nominal: float
-        Nominal outdoor temperature in Kelvin, default Mannheim (-10.5 °C)
     path : string
         if the Files should not be stored in default output path of TEASER,
         an alternative path can be specified as a full paths
@@ -181,7 +178,7 @@ def export_besmod(
                 out_file.write(example_template.render_unicode(
                     bldg=bldg,
                     project=prj,
-                    TOda_nominal=TOda_nominal,
+                    TOda_nominal=bldg.thermal_zones[0].t_outside,
                     THydSup_nominal=THydSup_nominal_bldg[bldg.name],
                     QBuiOld_flow_design=QBuiOld_flow_design[bldg.name],
                     THydSupOld_design=THydSupOld_design_bldg[bldg.name]))

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -60,7 +60,7 @@ def export_besmod(
         buildings = [buildings]
 
     supported_examples = ["TEASERHeatLoadCalculation",
-                          "ModelicaConferencePaper",
+                          "HeatPumpMonoenergetic",
                           "GasBoilerBuildingOnly"]
 
     dir_resources = os.path.join(path, "Resources")

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -13,7 +13,11 @@ def export_besmod(
         buildings,
         prj,
         path=None,
-        examples=None):
+        examples=None,
+        THydSup_nominal=None,
+        TOda_nominal=262.65,
+        QBuiOld_flow_design=None,
+        THydSupOld_design=None):
     """Exports buildings for BESMod simulation
 
     Exports one (if internal_id is not None) or all buildings as
@@ -33,6 +37,8 @@ def export_besmod(
     prj : instance of Project
         Instance of TEASER Project object to access Project related
         information, e.g. name or version of used libraries
+    TOda_nominal: float
+        Nominal outdoor temperature in Kelvin, default Mannheim (-10.5 °C)
     path : string
         if the Files should not be stored in default output path of TEASER,
         an alternative path can be specified as a full paths
@@ -44,12 +50,6 @@ def export_besmod(
 
     lookup : TemplateLookup object
         Instance of mako.TemplateLookup to store general functions for templates
-    zone_template_1 : Template object
-        Template for ThermalZoneRecord using 1 element model
-    zone_template_2 : Template object
-        Template for ThermalZoneRecord using 2 element model
-    zone_template_3 : Template object
-        Template for ThermalZoneRecord using 3 element model
     zone_template_4 : Template object
         Template for ThermalZoneRecord using 4 element model
     model_template : Template object
@@ -58,6 +58,21 @@ def export_besmod(
 
     if not isinstance(buildings, list):
         buildings = [buildings]
+
+    if THydSup_nominal is None and ("HeatPumpMonoenergetic" or "GasBoilerBuildingOnly" in examples):
+        raise ValueError("For the examples HeatPumpMonoenergetic and GasBoilerBuildingOnly "
+                         "the parameter THydSup_nominal needs to be set.")
+    # construct dict {bldg.name: THydSup_nominal_actual_value}
+    THydSup_nominal_bldg = _convert_THydSup_nominl_input(THydSup_nominal, buildings)
+    if THydSupOld_design is None:
+        THydSupOld_design_bldg = {bldg.name: "systemParameters.THydSup_nominal" for bldg in buildings}
+    else:
+        THydSupOld_design_bldg = _convert_THydSup_nominl_input(THydSupOld_design, buildings)
+
+    if QBuiOld_flow_design is None:
+        QBuiOld_flow_design = {bldg.name: "systemParameters.QBui_flow_nominal" for bldg in buildings}
+    else:
+        QBuiOld_flow_design = {bldg.name: _convert_to_zone_array(bldg, QBuiOld_flow_design[bldg.name]) for bldg in buildings}
 
     supported_examples = ["TEASERHeatLoadCalculation",
                           "HeatPumpMonoenergetic",
@@ -75,21 +90,6 @@ def export_besmod(
 
     lookup = TemplateLookup(directories=[utilities.get_full_path(
         os.path.join('data', 'output', 'modelicatemplate'))])
-    zone_template_1 = Template(
-        filename=utilities.get_full_path(
-            "data/output/modelicatemplate/AixLib"
-            "/AixLib_ThermalZoneRecord_OneElement"),
-        lookup=lookup)
-    zone_template_2 = Template(
-        filename=utilities.get_full_path(
-            "data/output/modelicatemplate/AixLib"
-            "/AixLib_ThermalZoneRecord_TwoElement"),
-        lookup=lookup)
-    zone_template_3 = Template(
-        filename=utilities.get_full_path(
-            "data/output/modelicatemplate/AixLib"
-            "/AixLib_ThermalZoneRecord_ThreeElement"),
-        lookup=lookup)
     zone_template_4 = Template(
         filename=utilities.get_full_path(
             "data/output/modelicatemplate/AixLib"
@@ -167,7 +167,7 @@ def export_besmod(
             out_file.close()
 
         for exp in examples:
-            exp_heat_load_calc_template = Template(
+            example_template = Template(
                 filename=utilities.get_full_path(
                     "data/output/modelicatemplate/BESMod/Example_" + exp),
                 lookup=lookup)
@@ -178,26 +178,31 @@ def export_besmod(
 
             with open(utilities.get_full_path(
                     os.path.join(bldg_path, exp + bldg.name + ".mo")), 'w') as out_file:
-                out_file.write(exp_heat_load_calc_template.render_unicode(
+                out_file.write(example_template.render_unicode(
                     bldg=bldg,
-                    project=prj))
+                    project=prj,
+                    TOda_nominal=TOda_nominal,
+                    THydSup_nominal=THydSup_nominal_bldg[bldg.name],
+                    QBuiOld_flow_design=QBuiOld_flow_design[bldg.name],
+                    THydSupOld_design=THydSupOld_design_bldg[bldg.name]))
                 out_file.close()
 
-            _help_example_script(bldg, dir_dymola, example_sim_plot_script, exp)  # ToDo fwu-hst: adapt for multiple examples
+            _help_example_script(bldg, dir_dymola, example_sim_plot_script,
+                                 exp)  # ToDo fwu-hst: adapt for multiple examples
 
         zone_path = os.path.join(bldg_path, bldg.name + "_DataBase")
 
         for zone in bldg.thermal_zones:
-            zone.use_conditions.with_heating = False # ToDo fwu-hst: really allways false for besmod?
+            zone.use_conditions.with_heating = False
             with open(utilities.get_full_path(os.path.join(
                     zone_path,
                     bldg.name + '_' + zone.name + '.mo')), 'w') as out_file:
                 if type(zone.model_attr).__name__ == "OneElement":
-                    out_file.write(zone_template_1.render_unicode(zone=zone))
+                    raise NotImplementedError("BESMod export is only implemented for four elements.")
                 elif type(zone.model_attr).__name__ == "TwoElement":
-                    out_file.write(zone_template_2.render_unicode(zone=zone))
+                    raise NotImplementedError("BESMod export is only implemented for four elements.")
                 elif type(zone.model_attr).__name__ == "ThreeElement":
-                    out_file.write(zone_template_3.render_unicode(zone=zone))
+                    raise NotImplementedError("BESMod export is only implemented for four elements.")
                 elif type(zone.model_attr).__name__ == "FourElement":
                     out_file.write(zone_template_4.render_unicode(zone=zone))
 
@@ -218,6 +223,51 @@ def export_besmod(
 
     print("Exports can be found here:")
     print(path)
+
+
+def _convert_THydSup_nominl_input(THydSup_nominal, buildings):
+    bldg_names = [bldg.name for bldg in buildings]
+    if isinstance(THydSup_nominal, (float, int)):
+        return {bldg.name: f"fill({THydSup_nominal},systemParameters.nZones)" for bldg in buildings}
+    elif isinstance(THydSup_nominal, dict):
+        THydSup_nominal_bldg = {}
+        if isinstance(list(THydSup_nominal.keys())[0], int):
+            for bldg in buildings:
+                temperature = _get_next_higher_year_value(THydSup_nominal, bldg.year_of_construction)
+                THydSup_nominal_bldg[bldg.name] = f"fill({temperature},systemParameters.nZones)"
+        elif set(list(THydSup_nominal.keys())) == set(bldg_names):
+            for bldg in buildings:
+                if isinstance(THydSup_nominal[bldg.name], (int, float)):
+                    THydSup_nominal_bldg[bldg.name] = f"fill({THydSup_nominal[bldg.name]},systemParameters.nZones)"
+                elif isinstance(THydSup_nominal[bldg.name], dict):
+                    THydSup_nominal_bldg[bldg.name] = _convert_to_zone_array(bldg, THydSup_nominal[bldg.name])
+                else:
+                    raise ValueError("If THydSup_nominal is specified for all buildings in a dictionary "
+                                     "the values must be either a single value for all thermal zones or "
+                                     "a dict with all building.thermal_zones.name as keys.")
+        else:
+            raise ValueError("If THydSup_nominal is given by a dictionary "
+                             "the keys must be all building names or construction years.")
+        return THydSup_nominal_bldg
+
+
+def _convert_to_zone_array(bldg, zone_dict):
+    tz_names = [tz.name for tz in bldg.thermal_zones]
+    if set(tz_names) == set(list(zone_dict.keys())):
+        array_string = "{"
+        for tz in tz_names:
+            array_string += str(zone_dict[tz]) + ","
+        return array_string[:-2] + "}"
+    else:
+        raise ValueError("Given thermal zones in dictionary are not matching.")
+
+
+def _get_next_higher_year_value(years_dict, given_year):
+    years = sorted(years_dict.keys())
+    for year in years:
+        if year > given_year:
+            return years_dict[year]
+    return years_dict[years[-1]]
 
 
 def _help_example_script(bldg, dir_dymola, test_script_template, example):

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -11,15 +11,15 @@ from teaser.logic.buildingobjects.building import Building
 
 
 def export_besmod(
-    buildings: Union[List[Building], Building],
-    prj: Project,
-    path: Optional[str] = None,
-    examples: Optional[List[str]] = None,
-    THydSup_nominal: Optional[Union[float, Dict[str, float]]] = None,
-    QBuiOld_flow_design: Optional[Dict[str, Dict[str, float]]] = None,
-    THydSupOld_design: Optional[Union[float, Dict[str, float]]] = None,
-    custom_examples: Optional[Dict[str, str]] = None,
-    custom_script: Optional[Dict[str, str]] = None
+        buildings: Union[List[Building], Building],
+        prj: Project,
+        path: Optional[str] = None,
+        examples: Optional[List[str]] = None,
+        THydSup_nominal: Optional[Union[float, Dict[str, float]]] = None,
+        QBuiOld_flow_design: Optional[Dict[str, Dict[str, float]]] = None,
+        THydSupOld_design: Optional[Union[float, Dict[str, float]]] = None,
+        custom_examples: Optional[Dict[str, str]] = None,
+        custom_script: Optional[Dict[str, str]] = None
 ) -> None:
     """
     Export building models for BESMod simulations.
@@ -77,32 +77,50 @@ def export_besmod(
 
     if prj.used_library_calc != "AixLib":
         raise AttributeError("BESMod export is only implemented for AixLib calculation.")
+
     if examples is None:
         examples = []
+
     if not isinstance(examples, list):
         examples = [examples]
-    supported_examples = ["TEASERHeatLoadCalculation",
-                          "HeatPumpMonoenergetic",
-                          "GasBoilerBuildingOnly"]
+
+    supported_examples = [
+        "TEASERHeatLoadCalculation",
+        "HeatPumpMonoenergetic",
+        "GasBoilerBuildingOnly",
+    ]
+
     for exp in examples:
         if exp not in supported_examples:
-            raise ValueError(f"Example {exp} is not supported. "
-                             f"Supported examples are {supported_examples}.")
+            raise ValueError(
+                f"Example {exp} is not supported. "
+                f"Supported examples are {supported_examples}."
+            )
 
     if THydSup_nominal is None and any(
-            example in examples for example in ["HeatPumpMonoenergetic", "GasBoilerBuildingOnly"]):
-        raise ValueError("Examples 'HeatPumpMonoenergetic' and 'GasBoilerBuildingOnly' "
-                         "require the `THydSup_nominal` parameter.")
+            example in examples for example in ["HeatPumpMonoenergetic", "GasBoilerBuildingOnly"]
+    ):
+        raise ValueError(
+            "Examples 'HeatPumpMonoenergetic' and 'GasBoilerBuildingOnly' "
+            "require the `THydSup_nominal` parameter."
+        )
 
     t_hyd_sup_nominal_bldg = convert_input(THydSup_nominal, buildings)
-    t_hyd_sup_old_design_bldg = convert_input(THydSupOld_design, buildings) if THydSupOld_design else \
-        {bldg.name: "systemParameters.THydSup_nominal" for bldg in buildings}
+    t_hyd_sup_old_design_bldg = (
+        convert_input(THydSupOld_design, buildings)
+        if THydSupOld_design
+        else {bldg.name: "systemParameters.THydSup_nominal" for bldg in buildings}
+    )
 
     if QBuiOld_flow_design is None:
-        QBuiOld_flow_design = {bldg.name: "systemParameters.QBui_flow_nominal" for bldg in buildings}
+        QBuiOld_flow_design = {
+            bldg.name: "systemParameters.QBui_flow_nominal" for bldg in buildings
+        }
     else:
-        QBuiOld_flow_design = {bldg.name: _convert_to_zone_array(bldg, QBuiOld_flow_design[bldg.name]) for bldg in
-                               buildings}
+        QBuiOld_flow_design = {
+            bldg.name: _convert_to_zone_array(bldg, QBuiOld_flow_design[bldg.name])
+            for bldg in buildings
+        }
 
     if custom_script is None:
         custom_script = {}

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -1,22 +1,26 @@
 """This module contains function for BESMod model generation"""
 
 import os
+from typing import Optional, Union, List, Dict
 from mako.template import Template
 from mako.lookup import TemplateLookup
 import teaser.logic.utilities as utilities
 import teaser.data.output.modelica_output as modelica_output
+from teaser.project import Project
+from teaser.logic.buildingobjects.building import Building
 
 
 def export_besmod(
-        buildings,
-        prj,
-        path=None,
-        examples=None,
-        THydSup_nominal=None,
-        QBuiOld_flow_design=None,
-        THydSupOld_design=None,
-        custom_examples=None,
-        custom_script=None):
+    buildings: Union[List[Building], Building],
+    prj: Project,
+    path: Optional[str] = None,
+    examples: Optional[List[str]] = None,
+    THydSup_nominal: Optional[Union[float, Dict[str, float]]] = None,
+    QBuiOld_flow_design: Optional[Dict[str, float]] = None,
+    THydSupOld_design: Optional[Union[float, Dict[str, float]]] = None,
+    custom_examples: Optional[Dict[str, str]] = None,
+    custom_script: Optional[Dict[str, str]] = None
+) -> None:
     """
     Export building models for BESMod simulations.
 
@@ -26,31 +30,31 @@ def export_besmod(
 
     Parameters
     ----------
-    buildings : list[Building] or Building
+    buildings : Union[List[Building], Building]
         TEASER Building instances to export as BESMod models. Can be a single
         Building or a list of Buildings.
     prj : Project
         TEASER Project instance containing project metadata such as library
         versions and weather file paths.
-    path : str, optional
-        Output directory path for the exported files. If not specified,
-        the default output path in TEASER is used.
-    examples : list[str], optional
+    examples : Optional[List[str]]
         Names of BESMod examples to export alongside the building models.
-    THydSup_nominal : float or dict, optional
+        Supported Examples: "TEASERHeatLoadCalculation", "HeatPumpMonoenergetic", and "GasBoilerBuildingOnly".
+    path : Optional[str]
+        Alternative output path for storing the exported files. If None, the default TEASER output path is used.
+    THydSup_nominal : Optional[Union[float, Dict[str, float]]]
         Nominal supply temperature(s) for the hydraulic system. Required for
         certain examples (e.g., HeatPumpMonoenergetic, GasBoilerBuildingOnly).
         See docstring of teaser.data.output.besmod_output.convert_input() for further information.
-    QBuiOld_flow_design : dict, optional
+    QBuiOld_flow_design : Optional[Dict[str, float]
         For partially retrofitted systems specify the old nominal heat flow
         of the Buildings in a dictionary with the building names as keys.
         By default, only the radiator transfer system is not retrofitted in BESMod.
-    THydSupOld_design : float or dict, optional
-        Design supply temperatures for old not retrofitted hydraulic systems.
-    custom_examples: dict, optional
+    THydSupOld_design : Optional[Union[float, Dict[str, float]]]
+        Design supply temperatures for old, non-retrofitted hydraulic systems.
+    custom_examples: Optional[Dict[str, str]]
         Specify custom examples with a dictionary containing the example name as the key and
         the path to the corresponding custom mako template as the value.
-    custom_script: dict, optional
+    custom_script: Optional[Dict[str, str]]
         Specify custom .mos scripts for the existing and custom examples with a dictionary
         containing the example name as the key and the path to the corresponding custom mako template as the value.
 
@@ -368,12 +372,12 @@ def _convert_heating_profile(heating_profile):
         start_time = 0
         width = 1e-50
     elif change_count == 1:
-        if heating_profile[0]<heating_profile[-1]:
+        if heating_profile[0] < heating_profile[-1]:
             start_time = 0
             width = 100 * change_indexes[0] / 24
         else:
             start_time = change_indexes[0] * 3600
-            width = 100 * (24-change_indexes[0]) / 24
+            width = 100 * (24 - change_indexes[0]) / 24
     elif change_count == 2:
         start_time = change_indexes[1] * 3600
         width = 100 * (24 - change_indexes[1] + change_indexes[0]) / 24

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -73,6 +73,8 @@ def export_besmod(
     if not isinstance(buildings, list):
         buildings = [buildings]
 
+    if examples is None:
+        examples = []
     if not isinstance(examples, list):
         examples = [examples]
     supported_examples = ["TEASERHeatLoadCalculation",
@@ -88,8 +90,8 @@ def export_besmod(
         raise ValueError("Examples 'HeatPumpMonoenergetic' and 'GasBoilerBuildingOnly' "
                          "require the `THydSup_nominal` parameter.")
 
-    THydSup_nominal_bldg = convert_input(THydSup_nominal, buildings)
-    THydSupOld_design_bldg = convert_input(THydSupOld_design, buildings) if THydSupOld_design else \
+    t_hyd_sup_nominal_bldg = convert_input(THydSup_nominal, buildings)
+    t_hyd_sup_old_design_bldg = convert_input(THydSupOld_design, buildings) if THydSupOld_design else \
         {bldg.name: "systemParameters.THydSup_nominal" for bldg in buildings}
 
     if QBuiOld_flow_design is None:
@@ -155,17 +157,17 @@ def export_besmod(
 
         def write_example_mo(example_template, example):
             with open(utilities.get_full_path(
-                    os.path.join(bldg_path, example + bldg.name + ".mo")), 'w') as out_file:
-                out_file.write(example_template.render_unicode(
+                    os.path.join(bldg_path, example + bldg.name + ".mo")), 'w') as model_file:
+                model_file.write(example_template.render_unicode(
                     bldg=bldg,
                     project=prj,
                     TOda_nominal=bldg.thermal_zones[0].t_outside,
-                    THydSup_nominal=THydSup_nominal_bldg[bldg.name],
+                    THydSup_nominal=t_hyd_sup_nominal_bldg[bldg.name],
                     QBuiOld_flow_design=QBuiOld_flow_design[bldg.name],
-                    THydSupOld_design=THydSupOld_design_bldg[bldg.name],
+                    THydSupOld_design=t_hyd_sup_old_design_bldg[bldg.name],
                     startTimeSetBack=start_time_set_back,
                     hoursSetBack=hours_set_back))
-                out_file.close()
+                model_file.close()
 
         for exp in examples:
             exp_template = Template(

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -381,7 +381,7 @@ def _convert_heating_profile(heating_profile):
         width = 100 * change_indexes[0] / 24
     elif change_count == 2:
         start_time = change_indexes[1] * 3600
-        width = 100 * (24-change_indexes[1] + change_indexes[0]) / 24
+        width = 100 * (24 - change_indexes[1] + change_indexes[0]) / 24
     else:
         raise ValueError("You have more than two temperature intervals in the heating profile."
                          "BESMod can only handel one heating set back.")

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -6,13 +6,12 @@ from mako.template import Template
 from mako.lookup import TemplateLookup
 import teaser.logic.utilities as utilities
 import teaser.data.output.modelica_output as modelica_output
-from teaser.project import Project
 from teaser.logic.buildingobjects.building import Building
 
 
 def export_besmod(
         buildings: Union[List[Building], Building],
-        prj: Project,
+        prj: 'Project',
         path: Optional[str] = None,
         examples: Optional[List[str]] = None,
         THydSup_nominal: Optional[Union[float, Dict[str, float]]] = None,

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -66,7 +66,7 @@ def export_besmod(
         buildings = [buildings]
 
     if not isinstance(examples, list):
-        examples =  [examples]
+        examples = [examples]
     supported_examples = ["TEASERHeatLoadCalculation",
                           "HeatPumpMonoenergetic",
                           "GasBoilerBuildingOnly"]
@@ -119,6 +119,14 @@ def export_besmod(
     for i, bldg in enumerate(buildings):
         bldg.bldg_height = bldg.number_of_floors * bldg.height_of_floors  # ToDo fwu-hst: better place? Create logic/calculation/besmod.py as for aixlib?
 
+        set_back_times = bldg.thermal_zones[0].use_conditions.set_back_times
+        start_time_set_back = 0
+        hours_set_back = 0
+        if set_back_times:
+            start_time_set_back = bldg.thermal_zones[0].use_conditions.set_back_times[1] * 3600
+            hours_set_back = 24 - bldg.thermal_zones[0].use_conditions.set_back_times[1] + \
+                             bldg.thermal_zones[0].use_conditions.set_back_times[0]
+
         ass_error = "BESMod export is only implemented for AixLib calculation."
         assert bldg.used_library_calc == 'AixLib', ass_error
 
@@ -160,7 +168,9 @@ def export_besmod(
                     TOda_nominal=bldg.thermal_zones[0].t_outside,
                     THydSup_nominal=THydSup_nominal_bldg[bldg.name],
                     QBuiOld_flow_design=QBuiOld_flow_design[bldg.name],
-                    THydSupOld_design=THydSupOld_design_bldg[bldg.name]))
+                    THydSupOld_design=THydSupOld_design_bldg[bldg.name],
+                    startTimeSetBack=start_time_set_back,
+                    hoursSetBack=hours_set_back))
                 out_file.close()
 
             _help_example_script(bldg, dir_dymola, example_sim_plot_script, exp)

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -236,7 +236,8 @@ def export_besmod(
     print(path)
 
 
-def convert_input(building_zones_input, buildings):
+def convert_input(building_zones_input: Union[float, Dict[Union[int, str], Union[float, Dict[str, float]]]],
+                  buildings: List[Building]) -> Dict[str, str]:
     """
     Convert input values for BESMod zone specific parameters to a dictionary.
 
@@ -250,15 +251,25 @@ def convert_input(building_zones_input, buildings):
 
     Parameters
     ----------
-    building_zones_input : float, int, or dict
-        Input value(s) for BESMod parameters. Can be a single value, or a
-        dictionary keyed by construction year, or building name.
-    buildings : list[Building]
+    building_zones_input : Union[float, Dict[Union[int, str], Union[float, Dict[str, float]]]]
+        Input value(s) for BESMod parameters. Can be a single value, a dictionary keyed by construction year,
+        or a dictionary keyed by building name.
+        Example:
+        - Single value: 328.15
+        - Dictionary keyed by construction year: {1970: 348.15, 1990: 328.15}
+        - Dictionary keyed by building name: {
+            "Building1": 328.15,
+            "Building2": {
+                "Zone1": 328.15,
+                "Zone2": 308.15
+            }
+        }
+    buildings : List[Building]
         List of TEASER Building instances.
 
     Returns
     -------
-    dict
+    Dict[str, str]
         Dictionary mapping building names to BESMod parameter input strings.
 
     Raises

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -114,7 +114,7 @@ def export_besmod(
     uses = [
         'Modelica(version="' + prj.modelica_info.version + '")',
         'AixLib(version="' + prj.buildings[-1].library_attr.version + '")',
-        'BESMod(version="0.5.0")']  # ToDo fwu-hst: BESMod version make attribute of AixLib?
+        'BESMod(version="' + prj.buildings[-1].library_attr.besmod_version + '")']
     modelica_output.create_package(
         path=path,
         name=prj.name,
@@ -125,8 +125,7 @@ def export_besmod(
     modelica_output.copy_weather_data(prj.weather_file_path, dir_resources)
 
     for i, bldg in enumerate(buildings):
-        bldg.bldg_height = bldg.number_of_floors * bldg.height_of_floors  # ToDo fwu-hst: better place? Create logic/calculation/besmod.py as for aixlib?
-
+        bldg.bldg_height = bldg.number_of_floors * bldg.height_of_floors 
         set_back_times = bldg.thermal_zones[0].use_conditions.set_back_times
         start_time_set_back = 0
         hours_set_back = 0

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -16,7 +16,7 @@ def export_besmod(
     path: Optional[str] = None,
     examples: Optional[List[str]] = None,
     THydSup_nominal: Optional[Union[float, Dict[str, float]]] = None,
-    QBuiOld_flow_design: Optional[Dict[str, float]] = None,
+    QBuiOld_flow_design: Optional[Dict[str, Dict[str, float]]] = None,
     THydSupOld_design: Optional[Union[float, Dict[str, float]]] = None,
     custom_examples: Optional[Dict[str, str]] = None,
     custom_script: Optional[Dict[str, str]] = None
@@ -45,9 +45,10 @@ def export_besmod(
         Nominal supply temperature(s) for the hydraulic system. Required for
         certain examples (e.g., HeatPumpMonoenergetic, GasBoilerBuildingOnly).
         See docstring of teaser.data.output.besmod_output.convert_input() for further information.
-    QBuiOld_flow_design : Optional[Dict[str, float]
+    QBuiOld_flow_design : Optional[Dict[str, Dict[str, float]]]
         For partially retrofitted systems specify the old nominal heat flow
-        of the Buildings in a dictionary with the building names as keys.
+        of all zones in the Buildings in a nested dictionary with
+        the building names and in a level below the zone names as keys.
         By default, only the radiator transfer system is not retrofitted in BESMod.
     THydSupOld_design : Optional[Union[float, Dict[str, float]]]
         Design supply temperatures for old, non-retrofitted hydraulic systems.

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -75,15 +75,9 @@ def export_besmod(
                           "HeatPumpMonoenergetic",
                           "GasBoilerBuildingOnly"]
 
-    dir_resources = os.path.join(path, "Resources")
-    if not os.path.exists(dir_resources):
-        os.mkdir(dir_resources)
-    dir_scripts = os.path.join(dir_resources, "Scripts")
-    if not os.path.exists(dir_scripts):
-        os.mkdir(dir_scripts)
-    dir_dymola = os.path.join(dir_scripts, "Dymola")
-    if not os.path.exists(dir_dymola):
-        os.mkdir(dir_dymola)
+    dir_resources = utilities.create_path(os.path.join(path, "Resources"))
+    dir_scripts = utilities.create_path(os.path.join(dir_resources, "Scripts"))
+    dir_dymola = utilities.create_path(os.path.join(dir_scripts, "Dymola"))
 
     lookup = TemplateLookup(directories=[utilities.get_full_path(
         os.path.join('data', 'output', 'modelicatemplate'))])

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -110,7 +110,7 @@ def export_besmod(
         package_list=buildings,
         addition=None,
         extra=None)
-    # _copy_weather_data(prj.weather_file_path, path)
+    aixlib_output._copy_weather_data(prj.weather_file_path, dir_resources)
 
     for i, bldg in enumerate(buildings):
         bldg.bldg_height = bldg.number_of_floors * bldg.height_of_floors  # ToDo fwu-hst: better place? Create logic/calculation/besmod.py as for aixlib?

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -125,7 +125,7 @@ def export_besmod(
     modelica_output.copy_weather_data(prj.weather_file_path, dir_resources)
 
     for i, bldg in enumerate(buildings):
-        bldg.bldg_height = bldg.number_of_floors * bldg.height_of_floors 
+        bldg.bldg_height = bldg.number_of_floors * bldg.height_of_floors
         set_back_times = bldg.thermal_zones[0].use_conditions.set_back_times
         start_time_set_back = 0
         hours_set_back = 0

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -6,7 +6,7 @@ import shutil
 from mako.template import Template
 from mako.lookup import TemplateLookup
 import teaser.logic.utilities as utilities
-import teaser.data.output.aixlib_output as aixlib_output
+import teaser.data.output.modelica_output as modelica_output
 
 
 def export_besmod(
@@ -95,16 +95,14 @@ def export_besmod(
         'Modelica(version="' + prj.modelica_info.version + '")',
         'AixLib(version="' + prj.buildings[-1].library_attr.version + '")']  # ToDo fwu-hst: BESMod version?
     aixlib_output._help_package(
+    modelica_output.create_package(
         path=path,
         name=prj.name,
-        uses=uses,
-        within=None)
-    aixlib_output._help_package_order(
+        uses=uses)
+    modelica_output.create_package_order(
         path=path,
-        package_list=buildings,
-        addition=None,
-        extra=None)
-    aixlib_output._copy_weather_data(prj.weather_file_path, dir_resources)
+        package_list=buildings)
+    modelica_output.copy_weather_data(prj.weather_file_path, dir_resources)
 
     for i, bldg in enumerate(buildings):
         bldg.bldg_height = bldg.number_of_floors * bldg.height_of_floors  # ToDo fwu-hst: better place? Create logic/calculation/besmod.py as for aixlib?
@@ -130,11 +128,10 @@ def export_besmod(
         example_bldg = [exp + bldg.name for exp in examples]
         example_bldg.append(bldg.name + "_DataBase")
 
-        aixlib_output._help_package(path=bldg_path, name=bldg.name, within=bldg.parent.name)
-        aixlib_output._help_package_order(
+        modelica_output.create_package(path=bldg_path, name=bldg.name, within=bldg.parent.name)
+        modelica_output.create_package_order(
             path=bldg_path,
             package_list=[bldg],
-            addition=None,
             extra=example_bldg)
 
         if bldg.building_id is None:
@@ -199,15 +196,14 @@ def export_besmod(
 
                 out_file.close()
 
-        aixlib_output._help_package(
+        modelica_output.create_package(
             path=zone_path,
             name=bldg.name + '_DataBase',
             within=prj.name + '.' + bldg.name)
-        aixlib_output._help_package_order(
+        modelica_output.create_package_order(
             path=zone_path,
             package_list=bldg.thermal_zones,
-            addition=bldg.name + "_",
-            extra=None)
+            addition=bldg.name + "_")
 
     # _copy_script_unit_tests(os.path.join(dir_scripts, "runUnitTests.py"))
     # _copy_reference_results(dir_resources, prj)  # ToDo fwu-hst: Creat reference results for example models

--- a/teaser/data/output/besmod_output.py
+++ b/teaser/data/output/besmod_output.py
@@ -133,13 +133,19 @@ def export_besmod(
 
     for i, bldg in enumerate(buildings):
         bldg.bldg_height = bldg.number_of_floors * bldg.height_of_floors
-        set_back_times = bldg.thermal_zones[0].use_conditions.set_back_times
-        start_time_set_back = 0
-        hours_set_back = 0
-        if set_back_times:
-            start_time_set_back = bldg.thermal_zones[0].use_conditions.set_back_times[1] * 3600
-            hours_set_back = 24 - bldg.thermal_zones[0].use_conditions.set_back_times[1] + \
-                             bldg.thermal_zones[0].use_conditions.set_back_times[0]
+        start_time_set_back = []
+        hours_set_back = []
+        heating_set_back = []
+        for tz in bldg.thermal_zones:
+            if tz.use_conditions.set_back_times:
+                heating_set_back.append(tz.use_conditions.heating_set_back)
+                start_time_set_back.append(tz.use_conditions.set_back_times[1] * 3600)
+                hours_set_back.append(100 * (24 - tz.use_conditions.set_back_times[1] +
+                                 tz.use_conditions.set_back_times[0])/24)
+            else:
+                heating_set_back.append(0)
+                start_time_set_back.append(0)
+                hours_set_back.append(0)
 
         ass_error = "BESMod export is only implemented for AixLib calculation."
         assert bldg.used_library_calc == 'AixLib', ass_error
@@ -171,8 +177,9 @@ def export_besmod(
                     TSetZone_nominal=t_set_zone_nominal_bldg[bldg.name],
                     QBuiOld_flow_design=QBuiOld_flow_design[bldg.name],
                     THydSupOld_design=t_hyd_sup_old_design_bldg[bldg.name],
-                    startTimeSetBack=start_time_set_back,
-                    hoursSetBack=hours_set_back))
+                    setBakTSetZone_amplitude=heating_set_back,
+                    setBakTSetZone_startTime=start_time_set_back,
+                    setBakTSetZone_width=hours_set_back))
                 model_file.close()
 
         for exp in examples:

--- a/teaser/data/output/ibpsa_output.py
+++ b/teaser/data/output/ibpsa_output.py
@@ -1,12 +1,12 @@
 # Created May 2016
 # TEASER Development Team
 
-"""ibpsa_output
+"""modelica_output
 
 This module contains function to call Templates for IBPSA model generation
 """
 
-import teaser.data.output.aixlib_output as ibpsa_output
+import teaser.data.output.modelica_output as modelica_output
 import os.path
 import teaser.logic.utilities as utilities
 from mako.template import Template
@@ -92,17 +92,15 @@ def export_ibpsa(
             "data/output/modelicatemplate/IBPSA/IBPSA_FourElements"),
         lookup=lookup)
 
-    ibpsa_output._help_package(
+    modelica_output.create_package(
         path=path,
         name=prj.name,
-        uses=uses,
-        within=None)
-    ibpsa_output._help_package_order(
+        uses=uses)
+    modelica_output.create_package_order(
         path=path,
         package_list=buildings,
-        addition=None,
         extra=None)
-    ibpsa_output._copy_weather_data(prj.weather_file_path, path)
+    modelica_output.copy_weather_data(prj.weather_file_path, path)
 
     for i, bldg in enumerate(buildings):
 
@@ -118,15 +116,14 @@ def export_ibpsa(
         utilities.create_path(utilities.get_full_path(
             os.path.join(bldg_path, bldg.name + "_Models")))
 
-        ibpsa_output._help_package(
+        modelica_output.create_package(
             path=bldg_path,
             name=bldg.name,
             within=bldg.parent.name)
 
-        ibpsa_output._help_package_order(
+        modelica_output.create_package_order(
             path=bldg_path,
             package_list=[],
-            addition=None,
             extra=[bldg.name + "_Models"])
 
         zone_path = os.path.join(
@@ -158,12 +155,12 @@ def export_ibpsa(
                                                                    library=library))
 
 
-        ibpsa_output._help_package(
+        modelica_output.create_package(
             path=zone_path,
             name=bldg.name + "_Models",
             within=prj.name + '.' + bldg.name)
 
-        ibpsa_output._help_package_order(
+        modelica_output.create_package_order(
             path=zone_path,
             package_list=bldg.thermal_zones,
             addition=bldg.name + "_")

--- a/teaser/data/output/modelica_output.py
+++ b/teaser/data/output/modelica_output.py
@@ -1,0 +1,82 @@
+"""This module contains function for all modelica model generations with AixLib, IBPSA and BESMod"""
+
+import os
+import shutil
+from mako.template import Template
+import teaser.logic.utilities as utilities
+
+
+def create_package(path, name, uses=None, within=None):
+    """creates a package.mo file
+
+    private function, do not call
+
+    Parameters
+    ----------
+
+    path : string
+        path of where the package.mo should be placed
+    name : string
+        name of the Modelica package
+    uses : [string]
+        list of used versions for the package in the form 'Library_name(version="x.x.x")'
+    within : string
+        path of Modelica package containing this package
+
+    """
+
+    package_template = Template(filename=utilities.get_full_path(
+        "data/output/modelicatemplate/package"))
+    with open(utilities.get_full_path(os.path.join(
+            path, "package.mo")), 'w') as out_file:
+
+        out_file.write(package_template.render_unicode(
+            name=name,
+            within=within,
+            uses=uses))
+        out_file.close()
+
+
+def create_package_order(path, package_list, addition=None, extra=None):
+    """creates a package.order file
+
+    private function, do not call
+
+    Parameters
+    ----------
+
+    path : string
+        path of where the package.order should be placed
+    package_list : [buildings or thermal_zones]
+        objects with the attribute name of all models or packages contained in the package
+    addition : string
+        if there should be a prefix of package_list.string it can
+        be specified
+    extra : [string]
+        list of extra packages or models not contained in package_list can be
+        specified
+
+    """
+
+    order_template = Template(filename=utilities.get_full_path(
+        "data/output/modelicatemplate/package_order"))
+    with open(utilities.get_full_path(
+            path + "/" + "package" + ".order"), 'w') as out_file:
+
+        out_file.write(order_template.render_unicode
+                       (list=package_list, addition=addition, extra=extra))
+        out_file.close()
+
+
+def copy_weather_data(source_path, destination_path):
+    """Copies the imported .mos weather file to the results folder.
+
+    Parameters
+    ----------
+    source_path : str
+        path of local weather file
+    destination_path : str
+        path of where the weather file should be placed
+    """
+
+    shutil.copy2(source_path, destination_path)

--- a/teaser/data/output/modelica_output.py
+++ b/teaser/data/output/modelica_output.py
@@ -1,4 +1,4 @@
-"""This module contains function for all modelica model generations with AixLib, IBPSA and BESMod"""
+"""This module contains functions for all modelica model generations with AixLib, IBPSA and BESMod"""
 
 import os
 import shutil

--- a/teaser/data/output/modelicatemplate/AixLib/AixLib_ThermalZoneRecord_FourElement
+++ b/teaser/data/output/modelicatemplate/AixLib/AixLib_ThermalZoneRecord_FourElement
@@ -67,7 +67,7 @@ record ${zone.parent.name}_${zone.name} "${zone.parent.name}_${zone.name}"
     lightingPowerSpecific = ${zone.use_conditions.lighting_power},
     ratioConvectiveHeatLighting = ${zone.use_conditions.ratio_conv_rad_lighting},
     useConstantACHrate = ${get_true_false(zone.use_conditions.use_constant_infiltration)},
-    baseACH = ${zone.use_conditions.infiltration_rate},
+    baseACH = ${zone.use_conditions.base_infiltration},
     maxUserACH = ${zone.use_conditions.max_user_infiltration},
     maxOverheatingACH = ${get_list(zone.use_conditions.max_overheating_infiltration)},
     maxSummerACH = ${get_list(zone.use_conditions.max_summer_infiltration)},

--- a/teaser/data/output/modelicatemplate/AixLib/AixLib_ThermalZoneRecord_OneElement
+++ b/teaser/data/output/modelicatemplate/AixLib/AixLib_ThermalZoneRecord_OneElement
@@ -66,7 +66,7 @@ record ${zone.parent.name}_${zone.name} "${zone.parent.name}_${zone.name}"
     lightingPowerSpecific = ${zone.use_conditions.lighting_power},
     ratioConvectiveHeatLighting = ${zone.use_conditions.ratio_conv_rad_lighting},
     useConstantACHrate = ${get_true_false(zone.use_conditions.use_constant_infiltration)},
-    baseACH = ${zone.use_conditions.infiltration_rate},
+    baseACH = ${zone.use_conditions.base_infiltration},
     maxUserACH = ${zone.use_conditions.max_user_infiltration},
     maxOverheatingACH = ${get_list(zone.use_conditions.max_overheating_infiltration)},
     maxSummerACH = ${get_list(zone.use_conditions.max_summer_infiltration)},

--- a/teaser/data/output/modelicatemplate/AixLib/AixLib_ThermalZoneRecord_ThreeElement
+++ b/teaser/data/output/modelicatemplate/AixLib/AixLib_ThermalZoneRecord_ThreeElement
@@ -66,7 +66,7 @@ record ${zone.parent.name}_${zone.name} "${zone.parent.name}_${zone.name}"
     lightingPowerSpecific = ${zone.use_conditions.lighting_power},
     ratioConvectiveHeatLighting = ${zone.use_conditions.ratio_conv_rad_lighting},
     useConstantACHrate = ${get_true_false(zone.use_conditions.use_constant_infiltration)},
-    baseACH = ${zone.use_conditions.infiltration_rate},
+    baseACH = ${zone.use_conditions.base_infiltration},
     maxUserACH = ${zone.use_conditions.max_user_infiltration},
     maxOverheatingACH = ${get_list(zone.use_conditions.max_overheating_infiltration)},
     maxSummerACH = ${get_list(zone.use_conditions.max_summer_infiltration)},

--- a/teaser/data/output/modelicatemplate/AixLib/AixLib_ThermalZoneRecord_TwoElement
+++ b/teaser/data/output/modelicatemplate/AixLib/AixLib_ThermalZoneRecord_TwoElement
@@ -66,7 +66,7 @@ record ${zone.parent.name}_${zone.name} "${zone.parent.name}_${zone.name}"
     lightingPowerSpecific = ${zone.use_conditions.lighting_power},
     ratioConvectiveHeatLighting = ${zone.use_conditions.ratio_conv_rad_lighting},
     useConstantACHrate = ${get_true_false(zone.use_conditions.use_constant_infiltration)},
-    baseACH = ${zone.use_conditions.infiltration_rate},
+    baseACH = ${zone.use_conditions.base_infiltration},
     maxUserACH = ${zone.use_conditions.max_user_infiltration},
     maxOverheatingACH = ${get_list(zone.use_conditions.max_overheating_infiltration)},
     maxSummerACH = ${get_list(zone.use_conditions.max_summer_infiltration)},

--- a/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
@@ -4,7 +4,10 @@ model GasBoilerBuildingOnly${bldg.name}
   extends BESMod.Systems.BaseClasses.TEASERExport.PartialGasBoilerBuildingOnly(
     redeclare ${bldg.name} building,
     userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(
-        "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt")),
+        "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
+        dTSetBack=${-bldg.thermal_zones[0].use_conditions.heating_set_back},
+        startTimeSetBack=${startTimeSetBack},
+        hoursSetBack=${hoursSetBack}),
     systemParameters(nZones=${len(bldg.thermal_zones)},
                      TOda_nominal=${TOda_nominal},
                      THydSup_nominal=${THydSup_nominal},

--- a/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
@@ -5,7 +5,11 @@ model GasBoilerBuildingOnly${bldg.name}
     redeclare ${bldg.name} building,
     userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(
         "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt")),
-    systemParameters(nZones=${len(bldg.thermal_zones)}));
+    systemParameters(nZones=${len(bldg.thermal_zones)},
+                     TOda_nominal=${TOda_nominal},
+                     THydSup_nominal=${THydSup_nominal},
+                     QBuiOld_flow_design=${QBuiOld_flow_design},
+                     THydSupOld_design=${THydSupOld_design}));
   extends Modelica.Icons.Example;
 
   annotation (experiment(StopTime=172800,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
@@ -17,6 +17,8 @@ model GasBoilerBuildingOnly${bldg.name}
                      THydSupOld_design=${THydSupOld_design},
                      filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
 
+  extends Modelica.Icons.Example;
+
   annotation (experiment(StopTime=172800,
      Interval=600,
      Tolerance=1e-06),

--- a/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
@@ -14,7 +14,6 @@ model GasBoilerBuildingOnly${bldg.name}
                      QBuiOld_flow_design=${QBuiOld_flow_design},
                      THydSupOld_design=${THydSupOld_design},
                      filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
-  extends Modelica.Icons.Example;
 
   annotation (experiment(StopTime=172800,
      Interval=600,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
@@ -10,7 +10,7 @@ model GasBoilerBuildingOnly${bldg.name}
             width=${get_list(setBakTSetZone_width)},
             startTime=${get_list(setBakTSetZone_startTime)})),
     systemParameters(nZones=${len(bldg.thermal_zones)},
-                     TSetZone_nominal=${TSetZone_nominal},
+                     TSetZone_nominal=${get_list(TSetZone_nominal)},
                      TOda_nominal=${TOda_nominal},
                      THydSup_nominal=${THydSup_nominal},
                      QBuiOld_flow_design=${QBuiOld_flow_design},

--- a/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
@@ -9,7 +9,8 @@ model GasBoilerBuildingOnly${bldg.name}
                      TOda_nominal=${TOda_nominal},
                      THydSup_nominal=${THydSup_nominal},
                      QBuiOld_flow_design=${QBuiOld_flow_design},
-                     THydSupOld_design=${THydSupOld_design}));
+                     THydSupOld_design=${THydSupOld_design},
+                     filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
   extends Modelica.Icons.Example;
 
   annotation (experiment(StopTime=172800,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
@@ -9,6 +9,7 @@ model GasBoilerBuildingOnly${bldg.name}
         startTimeSetBack=${startTimeSetBack},
         hoursSetBack=${hoursSetBack}),
     systemParameters(nZones=${len(bldg.thermal_zones)},
+                     TSetZone_nominal=${TSetZone_nominal},
                      TOda_nominal=${TOda_nominal},
                      THydSup_nominal=${THydSup_nominal},
                      QBuiOld_flow_design=${QBuiOld_flow_design},

--- a/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
@@ -1,59 +1,11 @@
 <%namespace file="/modelica_language/" import="get_true_false"/>
 within ${bldg.parent.name}.${bldg.name};
 model GasBoilerBuildingOnly${bldg.name}
-  extends BESMod.Systems.BaseClasses.PartialBuildingEnergySystem(
-    redeclare BESMod.Systems.Electrical.DirectGridConnectionSystem electrical,
+  extends BESMod.Systems.BaseClasses.TEASERExport.PartialGasBoilerBuildingOnly(
     redeclare ${bldg.name} building,
-    redeclare BESMod.Systems.Control.NoControl control,
-    redeclare BESMod.Systems.Ventilation.NoVentilation ventilation,
-    redeclare BESMod.Systems.Hydraulical.HydraulicSystem hydraulic(
-      energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial,
-      redeclare BESMod.Systems.Hydraulical.Generation.GasBoiler generation(
-        dTTra_nominal={10},
-        redeclare
-          BESMod.Systems.RecordsCollection.TemperatureSensors.DefaultSensor
-          parTemSen,
-        redeclare BESMod.Systems.RecordsCollection.Movers.DefaultMover parPum),
-      redeclare BESMod.Systems.Hydraulical.Control.GasBoiler control(
-        redeclare
-          BESMod.Systems.Hydraulical.Control.Components.ThermostaticValveController.ThermostaticValvePIControlled
-          valCtrl,
-        redeclare
-          BESMod.Systems.Hydraulical.Control.RecordsCollection.BasicBoilerPI
-          parPID,
-        redeclare
-          BESMod.Systems.Hydraulical.Control.Components.RelativeSpeedController.PID
-          PIDCtrl),
-      redeclare BESMod.Systems.Hydraulical.Distribution.BuildingOnly distribution(
-          nParallelDem=1),
-      redeclare BESMod.Systems.Hydraulical.Transfer.RadiatorPressureBased
-        transfer(
-        redeclare
-          BESMod.Systems.Hydraulical.Transfer.RecordsCollection.SteelRadiatorStandardPressureLossData
-          parTra,
-        redeclare BESMod.Systems.RecordsCollection.Movers.DefaultMover parPum,
-        redeclare
-          BESMod.Systems.Hydraulical.Transfer.RecordsCollection.RadiatorTransferData
-          parRad)),
-    redeclare BESMod.Systems.Demand.DHW.StandardProfiles DHW(
-      energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial,
-      redeclare BESMod.Systems.RecordsCollection.Movers.DefaultMover parPum,
-      redeclare BESMod.Systems.Demand.DHW.RecordsCollection.ProfileM DHWProfile,
-      redeclare BESMod.Systems.Demand.DHW.TappingProfiles.PassThrough calcmFlow),
-    redeclare BESMod.Systems.UserProfiles.TEASERProfiles userProfiles(
-        fileNameIntGains=Modelica.Utilities.Files.loadResource(
+    userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(
         "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt")),
-    redeclare BESMod.Systems.RecordsCollection.ParameterStudy.NoStudy
-      parameterStudy,
-    redeclare BESMod.Systems.RecordsCollection.ExampleSystemParameters
-      systemParameters(
-      nZones=${len(bldg.thermal_zones)},
-      QBui_flow_nominal=building.QRec_flow_nominal,
-      THydSup_nominal={338.15},
-      use_ventilation=false,
-      use_dhw=false,
-      use_elecHeating=false));
-
+    systemParameters(nZones=${len(bldg.thermal_zones)}));
   extends Modelica.Icons.Example;
 
   annotation (experiment(StopTime=172800,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_GasBoilerBuildingOnly
@@ -1,13 +1,14 @@
-<%namespace file="/modelica_language/" import="get_true_false"/>
+<%namespace file="/modelica_language/" import="get_list"/>
 within ${bldg.parent.name}.${bldg.name};
 model GasBoilerBuildingOnly${bldg.name}
   extends BESMod.Systems.BaseClasses.TEASERExport.PartialGasBoilerBuildingOnly(
     redeclare ${bldg.name} building,
     userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(
         "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
-        dTSetBack=${-bldg.thermal_zones[0].use_conditions.heating_set_back},
-        startTimeSetBack=${startTimeSetBack},
-        hoursSetBack=${hoursSetBack}),
+        setBakTSetZone(
+            amplitude=${get_list(setBakTSetZone_amplitude)},
+            width=${get_list(setBakTSetZone_width)},
+            startTime=${get_list(setBakTSetZone_startTime)})),
     systemParameters(nZones=${len(bldg.thermal_zones)},
                      TSetZone_nominal=${TSetZone_nominal},
                      TOda_nominal=${TOda_nominal},

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -14,8 +14,6 @@ model HeatPumpMonoenergetic${bldg.name}
         nZones=${len(bldg.thermal_zones)},
         QBui_flow_nominal=building.QRec_flow_nominal,
         THydSup_nominal=fill(328.15,systemParameters.nZones)));
-  extends Modelica.Icons.Example;
-
 
 annotation(experiment(StopTime=172800,
      Interval=600,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -5,20 +5,16 @@ model HeatPumpMonoenergetic${bldg.name}
     redeclare ${bldg.name} building(
       use_verboseEnergyBalance=false,
       energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial),
-    redeclare BESMod.Systems.UserProfiles.TEASERProfiles
-      userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(
-        "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
-        setBakTSetZone(
-            amplitude=${get_list(setBakTSetZone_amplitude)},
-            width=${get_list(setBakTSetZone_width)},
-            startTime=${get_list(setBakTSetZone_startTime)})),
+    userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(
+      "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
+      setBakTSetZone(
+        amplitude=${get_list(setBakTSetZone_amplitude)},
+        width=${get_list(setBakTSetZone_width)},
+        startTime=${get_list(setBakTSetZone_startTime)})),
     systemParameters(
-        use_hydraulic=true,
-        use_ventilation=true,
         nZones=${len(bldg.thermal_zones)},
         TSetZone_nominal=${get_list(TSetZone_nominal)},
         TOda_nominal=${TOda_nominal},
-        QBui_flow_nominal=building.QRec_flow_nominal,
         THydSup_nominal=${THydSup_nominal},
         QBuiOld_flow_design=${QBuiOld_flow_design},
         THydSupOld_design=${THydSupOld_design},

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -1,7 +1,7 @@
 <%namespace file="/modelica_language/" import="get_true_false"/>
 within ${bldg.parent.name}.${bldg.name};
-model ModelicaConferencePaper${bldg.name}
-  extends BESMod.Examples.ModelicaConferencePaper.PartialModelicaConferenceUseCase(
+model HeatPumpMonoenergetic${bldg.name}
+  extends BESMod.Systems.BaseClasses.TEASERExport.PartialHeatPumpMonoenergetic(
     redeclare ${bldg.name} building(
       use_verboseEnergyBalance=false,
       energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial),
@@ -21,6 +21,6 @@ annotation(experiment(StopTime=172800,
      Interval=600,
      Tolerance=1e-06),
    __Dymola_Commands(file=
-        "Resources/Scripts/Dymola/${bldg.name}/ModelicaConferencePaper${bldg.name}.mos"
+        "Resources/Scripts/Dymola/${bldg.name}/HeatPumpMonoenergetic${bldg.name}.mos"
         "Simulate and plot"));
-end ModelicaConferencePaper${bldg.name};
+end HeatPumpMonoenergetic${bldg.name};

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -1,4 +1,4 @@
-<%namespace file="/modelica_language/" import="get_true_false"/>
+<%namespace file="/modelica_language/" import="get_list"/>
 within ${bldg.parent.name}.${bldg.name};
 model HeatPumpMonoenergetic${bldg.name}
   extends BESMod.Systems.BaseClasses.TEASERExport.PartialHeatPumpMonoenergetic(
@@ -8,9 +8,10 @@ model HeatPumpMonoenergetic${bldg.name}
     redeclare BESMod.Systems.UserProfiles.TEASERProfiles
       userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(
         "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
-        dTSetBack=${-bldg.thermal_zones[0].use_conditions.heating_set_back},
-        startTimeSetBack=${startTimeSetBack},
-        hoursSetBack=${hoursSetBack}),
+        setBakTSetZone(
+            amplitude=${get_list(setBakTSetZone_amplitude)},
+            width=${get_list(setBakTSetZone_width)},
+            startTime=${get_list(setBakTSetZone_startTime)})),
     systemParameters(
         use_hydraulic=true,
         use_ventilation=true,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -12,8 +12,11 @@ model HeatPumpMonoenergetic${bldg.name}
         use_hydraulic=true,
         use_ventilation=true,
         nZones=${len(bldg.thermal_zones)},
+        TOda_nominal=${TOda_nominal},
         QBui_flow_nominal=building.QRec_flow_nominal,
-        THydSup_nominal=fill(328.15,systemParameters.nZones)));
+        THydSup_nominal=${THydSup_nominal},
+        QBuiOld_flow_design=${QBuiOld_flow_design},
+        THydSupOld_design=${THydSupOld_design}));
 
 annotation(experiment(StopTime=172800,
      Interval=600,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -16,7 +16,7 @@ model HeatPumpMonoenergetic${bldg.name}
         use_hydraulic=true,
         use_ventilation=true,
         nZones=${len(bldg.thermal_zones)},
-        TSetZone_nominal=${TSetZone_nominal},
+        TSetZone_nominal=${get_list(TSetZone_nominal)},
         TOda_nominal=${TOda_nominal},
         QBui_flow_nominal=building.QRec_flow_nominal,
         THydSup_nominal=${THydSup_nominal},

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -15,6 +15,7 @@ model HeatPumpMonoenergetic${bldg.name}
         use_hydraulic=true,
         use_ventilation=true,
         nZones=${len(bldg.thermal_zones)},
+        TSetZone_nominal=${TSetZone_nominal},
         TOda_nominal=${TOda_nominal},
         QBui_flow_nominal=building.QRec_flow_nominal,
         THydSup_nominal=${THydSup_nominal},

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -16,7 +16,8 @@ model HeatPumpMonoenergetic${bldg.name}
         QBui_flow_nominal=building.QRec_flow_nominal,
         THydSup_nominal=${THydSup_nominal},
         QBuiOld_flow_design=${QBuiOld_flow_design},
-        THydSupOld_design=${THydSupOld_design}));
+        THydSupOld_design=${THydSupOld_design},
+        filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
 
 annotation(experiment(StopTime=172800,
      Interval=600,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -20,6 +20,8 @@ model HeatPumpMonoenergetic${bldg.name}
         THydSupOld_design=${THydSupOld_design},
         filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
 
+  extends Modelica.Icons.Example;
+
 annotation(experiment(StopTime=172800,
      Interval=600,
      Tolerance=1e-06),

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -7,7 +7,10 @@ model HeatPumpMonoenergetic${bldg.name}
       energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial),
     redeclare BESMod.Systems.UserProfiles.TEASERProfiles
       userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(
-        "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt")),
+        "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
+        dTSetBack=${-bldg.thermal_zones[0].use_conditions.heating_set_back},
+        startTimeSetBack=${startTimeSetBack},
+        hoursSetBack=${hoursSetBack})),
     systemParameters(
         use_hydraulic=true,
         use_ventilation=true,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_HeatPumpMonoenergetic
@@ -10,7 +10,7 @@ model HeatPumpMonoenergetic${bldg.name}
         "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
         dTSetBack=${-bldg.thermal_zones[0].use_conditions.heating_set_back},
         startTimeSetBack=${startTimeSetBack},
-        hoursSetBack=${hoursSetBack})),
+        hoursSetBack=${hoursSetBack}),
     systemParameters(
         use_hydraulic=true,
         use_ventilation=true,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
@@ -1,4 +1,4 @@
-<%namespace file="/modelica_language/" import="get_true_false"/>
+<%namespace file="/modelica_language/" import="get_list"/>
 within ${bldg.parent.name}.${bldg.name};
 model TEASERHeatLoadCalculation${bldg.name}
   extends BESMod.Systems.BaseClasses.TEASERExport.PartialTEASERHeatLoadCalculation(
@@ -6,9 +6,10 @@ model TEASERHeatLoadCalculation${bldg.name}
     userProfiles(
         fileNameIntGains=Modelica.Utilities.Files.loadResource(
         "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
-        dTSetBack=${-bldg.thermal_zones[0].use_conditions.heating_set_back},
-        startTimeSetBack=${startTimeSetBack},
-        hoursSetBack=${hoursSetBack}),
+        setBakTSetZone(
+            amplitude=${get_list(setBakTSetZone_amplitude)},
+            width=${get_list(setBakTSetZone_width)},
+            startTime=${get_list(setBakTSetZone_startTime)})),
     systemParameters(nZones=${len(bldg.thermal_zones)},
                      TSetZone_nominal=${TSetZone_nominal},
                      TOda_nominal=${TOda_nominal},

--- a/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
@@ -11,7 +11,7 @@ model TEASERHeatLoadCalculation${bldg.name}
             width=${get_list(setBakTSetZone_width)},
             startTime=${get_list(setBakTSetZone_startTime)})),
     systemParameters(nZones=${len(bldg.thermal_zones)},
-                     TSetZone_nominal=${TSetZone_nominal},
+                     TSetZone_nominal=${get_list(TSetZone_nominal)},
                      TOda_nominal=${TOda_nominal},
                      filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
 

--- a/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
@@ -1,7 +1,7 @@
 <%namespace file="/modelica_language/" import="get_true_false"/>
 within ${bldg.parent.name}.${bldg.name};
 model TEASERHeatLoadCalculation${bldg.name}
-  extends BESMod.Examples.TEASERHeatLoadCalculation.PartialCalculation(
+  extends BESMod.Systems.BaseClasses.TEASERExport.PartialTEASERHeatLoadCalculation(
     redeclare ${bldg.name} building,
     userProfiles(dTSetBack=3,
         fileNameIntGains=Modelica.Utilities.Files.loadResource(

--- a/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
@@ -6,7 +6,8 @@ model TEASERHeatLoadCalculation${bldg.name}
     userProfiles(dTSetBack=3,
         fileNameIntGains=Modelica.Utilities.Files.loadResource(
         "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt")),
-    systemParameters(nZones=${len(bldg.thermal_zones)}));
+    systemParameters(nZones=${len(bldg.thermal_zones)},
+                     TOda_nominal=${TOda_nominal}));
 
   annotation (
     experiment(StopTime=172800,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
@@ -3,9 +3,12 @@ within ${bldg.parent.name}.${bldg.name};
 model TEASERHeatLoadCalculation${bldg.name}
   extends BESMod.Systems.BaseClasses.TEASERExport.PartialTEASERHeatLoadCalculation(
     redeclare ${bldg.name} building,
-    userProfiles(dTSetBack=3,
+    userProfiles(
         fileNameIntGains=Modelica.Utilities.Files.loadResource(
-        "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt")),
+        "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
+        dTSetBack=${-bldg.thermal_zones[0].use_conditions.heating_set_back},
+        startTimeSetBack=${startTimeSetBack},
+        hoursSetBack=${hoursSetBack}),
     systemParameters(nZones=${len(bldg.thermal_zones)},
                      TOda_nominal=${TOda_nominal},
                      filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));

--- a/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
@@ -7,7 +7,8 @@ model TEASERHeatLoadCalculation${bldg.name}
         fileNameIntGains=Modelica.Utilities.Files.loadResource(
         "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt")),
     systemParameters(nZones=${len(bldg.thermal_zones)},
-                     TOda_nominal=${TOda_nominal}));
+                     TOda_nominal=${TOda_nominal},
+                     filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
 
   annotation (
     experiment(StopTime=172800,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
@@ -7,7 +7,6 @@ model TEASERHeatLoadCalculation${bldg.name}
         fileNameIntGains=Modelica.Utilities.Files.loadResource(
         "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt")),
     systemParameters(nZones=${len(bldg.thermal_zones)}));
-  extends Modelica.Icons.Example;
 
   annotation (
     experiment(StopTime=172800,

--- a/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
@@ -10,6 +10,7 @@ model TEASERHeatLoadCalculation${bldg.name}
         startTimeSetBack=${startTimeSetBack},
         hoursSetBack=${hoursSetBack}),
     systemParameters(nZones=${len(bldg.thermal_zones)},
+                     TSetZone_nominal=${TSetZone_nominal},
                      TOda_nominal=${TOda_nominal},
                      filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
 

--- a/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Example_TEASERHeatLoadCalculation
@@ -15,6 +15,8 @@ model TEASERHeatLoadCalculation${bldg.name}
                      TOda_nominal=${TOda_nominal},
                      filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
 
+  extends Modelica.Icons.Example;
+
   annotation (
     experiment(StopTime=172800,
      Interval=600,

--- a/teaser/data/output/modelicatemplate/BESMod/Script_GasBoilerBuildingOnly
+++ b/teaser/data/output/modelicatemplate/BESMod/Script_GasBoilerBuildingOnly
@@ -1,5 +1,5 @@
 
-simulateModel("${project.name}.${bldg.name}.GasBoilerBuildingOnly${bldg.name}", stopTime=172800, method="dassl", tolerance=1e-06, resultFile="GasBoilerBuildingOnly");
+simulateModel("${project.name}.${bldg.name}.GasBoilerBuildingOnly${bldg.name}", stopTime=172800, method="dassl", tolerance=1e-06, resultFile="GasBoilerBuildingOnly${bldg.name}");
 
 createPlot(id=1, position={75, 70, 1210, 600}, y={"weaDat.weaBus.TDryBul"}, grid=true, subPlot=1, colors={{28,108,200}});
 createPlot(id=1, y={"hydraulic.generation.sigBusGen.TBoiOut"}, grid=true, subPlot=2, colors={{238,46,47}});

--- a/teaser/data/output/modelicatemplate/BESMod/Script_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Script_HeatPumpMonoenergetic
@@ -1,4 +1,4 @@
-simulateModel("${project.name}.${bldg.name}.HeatPumpMonoenergetic${bldg.name}", stopTime=864000, method="dassl", tolerance=1e-06, resultFile="HeatPumpMonoenergetic${bldg.name}");
+simulateModel("${project.name}.${bldg.name}.HeatPumpMonoenergetic${bldg.name}", stopTime=172800, method="dassl", tolerance=1e-06, resultFile="HeatPumpMonoenergetic${bldg.name}");
 createPlot(id=2, position={75, 70, 1210, 240}, y={"electrical.distribution.OutputDistr.PEleGen.value","electrical.distribution.OutputDistr.PEleLoa.value"}, grid=true, subPlot=1, colors={{28,108,200},{238,46,47}});
 createPlot(id=2, position={75, 70, 1210, 240}, y={"hydraulic.distribution.sigBusDistr.TStoDHWTopMea","hydraulic.distribution.sigBusDistr.TStoBufTopMea","hydraulic.generation.sigBusGen.TGenOutMea"}, grid=true, subPlot=2, colors={{28,108,200},{238,46,47},{0,140,72}});
 createPlot(id=2, position={75, 70, 1210, 240}, y={"ventilation.generation.TSup.T","ventilation.generation.weaBus.TDryBul","building.buiMeaBus.TZoneMea[1]"}, grid=true, subPlot=3, colors={{28,108,200},{238,46,47},{0,140,72}});

--- a/teaser/data/output/modelicatemplate/BESMod/Script_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Script_HeatPumpMonoenergetic
@@ -1,4 +1,4 @@
-simulateModel("${project.name}.${bldg.name}.HeatPumpMonoenergetic${bldg.name}", stopTime=864000, method="dassl", tolerance=1e-06, resultFile="TEASERBuilding");
+simulateModel("${project.name}.${bldg.name}.HeatPumpMonoenergetic${bldg.name}", stopTime=864000, method="dassl", tolerance=1e-06, resultFile="HeatPumpMonoenergetic${bldg.name}");
 createPlot(id=2, position={75, 70, 1210, 240}, y={"electrical.distribution.OutputDistr.PEleGen.value","electrical.distribution.OutputDistr.PEleLoa.value"}, grid=true, subPlot=1, colors={{28,108,200},{238,46,47}});
 createPlot(id=2, position={75, 70, 1210, 240}, y={"hydraulic.distribution.sigBusDistr.TStoDHWTopMea","hydraulic.distribution.sigBusDistr.TStoBufTopMea","hydraulic.generation.sigBusGen.TGenOutMea"}, grid=true, subPlot=2, colors={{28,108,200},{238,46,47},{0,140,72}});
 createPlot(id=2, position={75, 70, 1210, 240}, y={"ventilation.generation.TSup.T","ventilation.generation.weaBus.TDryBul","building.buiMeaBus.TZoneMea[1]"}, grid=true, subPlot=3, colors={{28,108,200},{238,46,47},{0,140,72}});

--- a/teaser/data/output/modelicatemplate/BESMod/Script_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Script_HeatPumpMonoenergetic
@@ -1,4 +1,4 @@
 simulateModel("${project.name}.${bldg.name}.HeatPumpMonoenergetic${bldg.name}", stopTime=864000, method="dassl", tolerance=1e-06, resultFile="TEASERBuilding");
-createPlot(id=2, position={75, 70, 1210, 240}, y={"electrical.distribution.batterySimple.PLoad","electrical.distribution.batterySimple.PCharge"}, grid=true, subPlot=1, colors={{28,108,200},{238,46,47}});
+createPlot(id=2, position={75, 70, 1210, 240}, y={"electrical.distribution.OutputDistr.PEleGen.value","electrical.distribution.OutputDistr.PEleLoa.value"}, grid=true, subPlot=1, colors={{28,108,200},{238,46,47}});
 createPlot(id=2, position={75, 70, 1210, 240}, y={"hydraulic.distribution.sigBusDistr.TStoDHWTopMea","hydraulic.distribution.sigBusDistr.TStoBufTopMea","hydraulic.generation.sigBusGen.TGenOutMea"}, grid=true, subPlot=2, colors={{28,108,200},{238,46,47},{0,140,72}});
 createPlot(id=2, position={75, 70, 1210, 240}, y={"ventilation.generation.TSup.T","ventilation.generation.weaBus.TDryBul","building.buiMeaBus.TZoneMea[1]"}, grid=true, subPlot=3, colors={{28,108,200},{238,46,47},{0,140,72}});

--- a/teaser/data/output/modelicatemplate/BESMod/Script_HeatPumpMonoenergetic
+++ b/teaser/data/output/modelicatemplate/BESMod/Script_HeatPumpMonoenergetic
@@ -1,4 +1,4 @@
-simulateModel("${project.name}.${bldg.name}.ModelicaConferencePaper${bldg.name}", stopTime=864000, method="dassl", tolerance=1e-06, resultFile="TEASERBuilding");
+simulateModel("${project.name}.${bldg.name}.HeatPumpMonoenergetic${bldg.name}", stopTime=864000, method="dassl", tolerance=1e-06, resultFile="TEASERBuilding");
 createPlot(id=2, position={75, 70, 1210, 240}, y={"electrical.distribution.batterySimple.PLoad","electrical.distribution.batterySimple.PCharge"}, grid=true, subPlot=1, colors={{28,108,200},{238,46,47}});
 createPlot(id=2, position={75, 70, 1210, 240}, y={"hydraulic.distribution.sigBusDistr.TStoDHWTopMea","hydraulic.distribution.sigBusDistr.TStoBufTopMea","hydraulic.generation.sigBusGen.TGenOutMea"}, grid=true, subPlot=2, colors={{28,108,200},{238,46,47},{0,140,72}});
 createPlot(id=2, position={75, 70, 1210, 240}, y={"ventilation.generation.TSup.T","ventilation.generation.weaBus.TDryBul","building.buiMeaBus.TZoneMea[1]"}, grid=true, subPlot=3, colors={{28,108,200},{238,46,47},{0,140,72}});

--- a/teaser/data/output/modelicatemplate/BESMod/Script_TEASERHeatLoadCalculation
+++ b/teaser/data/output/modelicatemplate/BESMod/Script_TEASERHeatLoadCalculation
@@ -1,5 +1,5 @@
 
-simulateModel("${project.name}.${bldg.name}.TEASERHeatLoadCalculation${bldg.name}", stopTime=172800, method="dassl", tolerance=1e-06, resultFile="Example");
+simulateModel("${project.name}.${bldg.name}.TEASERHeatLoadCalculation${bldg.name}", stopTime=172800, method="dassl", tolerance=1e-06, resultFile="TEASERHeatLoadCalculation${bldg.name}");
 
 createPlot(id=1, position={75, 70, 1210, 600}, y={"weaDat.weaBus.TDryBul"}, grid=true, subPlot=1, colors={{28,108,200}});
 createPlot(id=1, y={"outputs.building.TZone[1]"}, grid=true, subPlot=2, colors={{0,140,72}});

--- a/teaser/data/output/teaserjson_output.py
+++ b/teaser/data/output/teaserjson_output.py
@@ -191,7 +191,7 @@ def save_teaser_json(path, project):
             ] = zone.use_conditions.use_constant_infiltration
             zone_out["use_conditions"][
                 "infiltration_rate"
-            ] = zone.use_conditions.infiltration_rate
+            ] = zone.use_conditions.base_infiltration
             zone_out["use_conditions"][
                 "max_user_infiltration"
             ] = zone.use_conditions.max_user_infiltration

--- a/teaser/data/output/teaserjson_output.py
+++ b/teaser/data/output/teaserjson_output.py
@@ -190,7 +190,7 @@ def save_teaser_json(path, project):
                 "use_constant_infiltration"
             ] = zone.use_conditions.use_constant_infiltration
             zone_out["use_conditions"][
-                "infiltration_rate"
+                "base_infiltration"
             ] = zone.use_conditions.base_infiltration
             zone_out["use_conditions"][
                 "max_user_infiltration"

--- a/teaser/data/output/usecond_output.py
+++ b/teaser/data/output/usecond_output.py
@@ -102,7 +102,7 @@ def save_use_conditions(use_cond, data_class):
             "use_constant_infiltration"
         ] = use_cond.use_constant_infiltration
         data_class.conditions_bind[use_cond.usage][
-            "infiltration_rate"
+            "base_infiltration"
         ] = use_cond.base_infiltration
         data_class.conditions_bind[use_cond.usage][
             "max_user_infiltration"

--- a/teaser/data/output/usecond_output.py
+++ b/teaser/data/output/usecond_output.py
@@ -103,7 +103,7 @@ def save_use_conditions(use_cond, data_class):
         ] = use_cond.use_constant_infiltration
         data_class.conditions_bind[use_cond.usage][
             "infiltration_rate"
-        ] = use_cond.infiltration_rate
+        ] = use_cond.base_infiltration
         data_class.conditions_bind[use_cond.usage][
             "max_user_infiltration"
         ] = use_cond.max_user_infiltration

--- a/teaser/examples/converter.toml
+++ b/teaser/examples/converter.toml
@@ -39,3 +39,9 @@ filename = "teaser/examples/e7_retrofit.py"
 func_name = "example_retrofit_building"
 md_path = "docs/source/examples"
 ipynb_path = "docs/jupyter_notebooks"
+
+[[ExampleFile]]
+filename = "teaser/examples/e11_export_besmod_models.py"
+func_name = "example_export_besmod"
+md_path = "docs/source/examples"
+ipynb_path = "docs/jupyter_notebooks"

--- a/teaser/examples/e11_export_besmod_models.py
+++ b/teaser/examples/e11_export_besmod_models.py
@@ -1,5 +1,4 @@
 # # Example 11: Export Modelica models for BESMod library using TEASER API
-
 # This module demonstrates how to export building models from a TEASER project
 # to ready-to-run simulation models for the Modelica BESMod library.
 # BESMod enables seamless integration with state-of-the-art energy systems,
@@ -9,7 +8,7 @@
 # AixLib focuses on ideal heat demand calculation, and IBPSA on
 # free floating temperature without an ideal heater.
 # You can execute this example using
-# [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/master?labpath=docs%2Fjupyter_notebooks)
+# [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/main?labpath=docs%2Fjupyter_notebooks)
 
 import teaser.examples.e1_generate_archetype as e1
 import teaser.logic.utilities as utilities
@@ -20,6 +19,7 @@ def example_export_besmod(save_dir_path=None):
     """This function demonstrates the export to Modelica library BESMod using
     the API function of TEASER"""
 
+    # ## Standard export
     # In e1_generate_archetype we created a Project with three archetype
     # buildings to get this Project we rerun this example
 
@@ -103,6 +103,7 @@ def example_export_besmod(save_dir_path=None):
         examples=examples
     )
 
+    # ## Partial retrofit export
     # The partial retrofit option of the energy system in BESMod can also be utilized.
     # For more information on this see BESMod.UsersGuide.GettingStarted.Parameterization.
     # To enable this here, the nominal heat flow of each zone in the building must be extracted prior to the retrofit.
@@ -135,6 +136,7 @@ def example_export_besmod(save_dir_path=None):
         examples=examples
     )
 
+    # ## Custom export
     # Additionally, we have the flexibility to define custom templates for including buildings in specific setups.
     # For instance, a custom template is defined here to include the building in the
     # ModelicaConferencePaper example from BESMod, which features an integrated battery system.
@@ -172,7 +174,7 @@ def example_export_besmod(save_dir_path=None):
     # end
     # ModelicaConferencePaper${bldg.name};
 
-    prj.name = "ArchetypeExample_total_retrofit"
+    prj.name = "ArchetypeExample_custom"
 
     custom_template_path = os.path.join(
         os.path.dirname(__file__), "examplefiles", "custom_besmod_templates"

--- a/teaser/examples/e11_export_besmod_models.py
+++ b/teaser/examples/e11_export_besmod_models.py
@@ -151,6 +151,8 @@ def example_export_besmod(save_dir_path=None):
     #                      filNamWea = Modelica.Utilities.Files.loadResource(
     #                           "modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
     #
+    #    extends Modelica.Icons.Example;
+    #
     #     annotation(experiment(StopTime=172800,
     #                           Interval=600,
     #                           Tolerance=1e-06),

--- a/teaser/examples/e11_export_besmod_models.py
+++ b/teaser/examples/e11_export_besmod_models.py
@@ -2,6 +2,12 @@
 
 # This module demonstrates how to export building models from a TEASER project
 # to ready-to-run simulation models for the Modelica BESMod library.
+# BESMod enables seamless integration with state-of-the-art energy systems,
+# such as heat pumps and photovoltaic systems. These systems can be utilized
+# to generate primary energy demand curves (e.g., for electricity or gas) or
+# to conduct in-depth analyses of building energy systems. In contrast,
+# AixLib focuses on ideal heat demand calculation, and IBPSA on
+# free floating temperature without an ideal heater.
 # You can execute this example using
 # [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/master?labpath=docs%2Fjupyter_notebooks)
 
@@ -21,18 +27,21 @@ def example_export_besmod(save_dir_path=None):
 
     # Configure project settings to ensure compatibility with BESMod. The BESMod
     # library uses the AixLib.ThermalZones.ReducedOrder.ThermalZone.ThermalZone model
-    # with 4 elements for the demand building model. Set these parameters in the project:
+    # with 4 elements for the demand building model. Other numbers of elements are possible,
+    # but compatability with ARoof for PV and AFloor for UFH systems must be checked first.
+    # Set these parameters in the project:
     prj.used_library_calc = 'AixLib'
     prj.number_of_elements_calc = 4
 
     # BESMod allows building models to be included in predefined example energy systems:
     examples = [
         "TEASERHeatLoadCalculation",  # Ideal electric heater for heat load calculations
-        "HeatPumpMonoenergetic",  # Heat pump with radiators, buffer storage, and PV
+        "HeatPumpMonoenergetic",  # Heat pump with radiators, buffer and DHW storage, and PV
         "GasBoilerBuildingOnly"  # Gas boiler with radiators
     ]
 
-    # For hydraulic systems, specify the nominal hydraulic supply temperature.
+    # For the hydraulic systems, you have to specify a nominal supply temperature
+    # for heat transfer, e.g. in radiators.
     # Multiple options are available:
 
     # Option 1: Set a single value for all buildings and zones.
@@ -53,7 +62,7 @@ def example_export_besmod(save_dir_path=None):
                        "ResidentialBuildingTabulaMulti": 328.15}
 
     # Option 3: Specify values based on construction year.
-    # Here the value of the next higher specified year is set to the building.
+    # Here, the value of the next higher specified year is set to the building.
     # The classification here is taken from:
     # https://www.ffe.de/projekte/waermepumpen-fahrplan-finanzielle-kipppunkte-zur-modernisierung-mit-waermepumpen-im-wohngebaeudebestand/
     THydSup_nominal = {
@@ -66,7 +75,7 @@ def example_export_besmod(save_dir_path=None):
     # In the examples, the parameters for BESMod.Systems.UserProfiles.TEASERProfiles are configured,
     # including internal gains and heating profiles for each zone.
     # BESMod requires 24-hour heating profiles, which are used
-    # to define the parameters of the setBakTSetZone Pulse block.
+    # to define the parameters of the `setBakTSetZone` Pulse block.
     # By default, the TEASER profiles are applied, but these can be customized if needed.
 
     # Additionally, location-specific parameters must be set, which can be achieved using the following function.
@@ -95,7 +104,8 @@ def example_export_besmod(save_dir_path=None):
     )
 
     # The partial retrofit option of the energy system in BESMod can also be utilized.
-    # To enable this, the nominal heat flow of each zone in the building must be extracted prior to the retrofit.
+    # For more information on this see BESMod.UsersGuide.GettingStarted.Parameterization.
+    # To enable this here, the nominal heat flow of each zone in the building must be extracted prior to the retrofit.
     QBuiOld_flow_design = {
         bldg.name: {
             tz.name: tz.model_attr.heat_load for tz in bldg.thermal_zones

--- a/teaser/examples/e11_export_besmod_models.py
+++ b/teaser/examples/e11_export_besmod_models.py
@@ -15,7 +15,7 @@ import teaser.logic.utilities as utilities
 import os
 
 
-def example_export_besmod(save_dir_path=None):
+def example_export_besmod():
     """This function demonstrates the export to Modelica library BESMod using
     the API function of TEASER"""
 
@@ -99,7 +99,7 @@ def example_export_besmod(save_dir_path=None):
     # Export all buildings to BESMod and include them in predefined example systems.
     path = prj.export_besmod(
         THydSup_nominal=THydSup_nominal,
-        path=save_dir_path,
+        path=None,
         examples=examples
     )
 
@@ -132,7 +132,7 @@ def example_export_besmod(save_dir_path=None):
     path = prj.export_besmod(
         THydSup_nominal=THydSup_nominal,
         QBuiOld_flow_design=QBuiOld_flow_design,
-        path=save_dir_path,
+        path=None,
         examples=examples
     )
 
@@ -142,6 +142,7 @@ def example_export_besmod(save_dir_path=None):
     # ModelicaConferencePaper example from BESMod, which features an integrated battery system.
 
     # Custom template
+    # ```
     # < %namespace file = "/modelica_language/" import="get_list" / >
     # within ${bldg.parent.name}.${bldg.name};
     # model ModelicaConferencePaper${bldg.name}
@@ -173,6 +174,7 @@ def example_export_besmod(save_dir_path=None):
     #                                  "Simulate and plot"));
     # end
     # ModelicaConferencePaper${bldg.name};
+    # ```
 
     prj.name = "ArchetypeExample_custom"
 
@@ -192,7 +194,7 @@ def example_export_besmod(save_dir_path=None):
 
     path = prj.export_besmod(
         THydSup_nominal=THydSup_nominal,
-        path=save_dir_path,
+        path=None,
         examples=examples,
         custom_examples=custom_example_template,
         custom_script=custom_script
@@ -202,6 +204,6 @@ def example_export_besmod(save_dir_path=None):
 
 
 if __name__ == '__main__':
-    example_export_besmod(save_dir_path=None)
+    example_export_besmod()
 
     print("Example 11: That's it! :)")

--- a/teaser/examples/e11_export_besmod_models.py
+++ b/teaser/examples/e11_export_besmod_models.py
@@ -1,4 +1,4 @@
-# # Example 4: Export Modelica models for BESMod library using TEASER API
+# # Example 11: Export Modelica models for BESMod library using TEASER API
 
 # This module demonstrates how to export building models from a TEASER project
 # to ready-to-run simulation models for the Modelica BESMod library.
@@ -190,4 +190,4 @@ def example_export_besmod(save_dir_path=None):
 if __name__ == '__main__':
     example_export_besmod(save_dir_path=None)
 
-    print("Example 4: That's it! :)")
+    print("Example 11: That's it! :)")

--- a/teaser/examples/e1_generate_archetype.py
+++ b/teaser/examples/e1_generate_archetype.py
@@ -17,7 +17,7 @@ def example_generate_archetype():
     # Be careful: Dymola does not like whitespaces in names and filenames, thus we will delete them anyway in TEASER.
 
     prj = Project()
-    prj.name = "ArchetypeExample_neu"
+    prj.name = "ArchetypeExample"
 
     # There are two different types of archetype groups: residential and
     # non-residential buildings. Two API functions offer the opportunity to

--- a/teaser/examples/e1_generate_archetype.py
+++ b/teaser/examples/e1_generate_archetype.py
@@ -17,7 +17,7 @@ def example_generate_archetype():
     # Be careful: Dymola does not like whitespaces in names and filenames, thus we will delete them anyway in TEASER.
 
     prj = Project()
-    prj.name = "ArchetypeExample"
+    prj.name = "ArchetypeExample_neu"
 
     # There are two different types of archetype groups: residential and
     # non-residential buildings. Two API functions offer the opportunity to

--- a/teaser/examples/e2_export_aixlib_models.py
+++ b/teaser/examples/e2_export_aixlib_models.py
@@ -1,8 +1,11 @@
 # # Example 2: Export Modelica models for AixLib library using TEASER API
 
 # This module contains an example how to export buildings from a TEASER
-# project to ready-to-run simulation models for Modelica library AixLib. These
-# models will only simulate using Dymola, the reason for this are state
+# project to ready-to-run simulation models for Modelica library AixLib.
+# AixLib focuses on ideal hat demand calculation. In contrast,
+# IBPSA focuses on the free floating temperature and has no ideal heater,
+# and BESMod on the coupling to state-of-the-art energy systems.
+# These models will only simulate using Dymola, the reason for this are state
 # machines that are used in one AixLib specific AHU model.
 # You can run this example using the [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/main?labpath=docs%2Fjupyter_notebooks)
 

--- a/teaser/examples/e2_export_aixlib_models.py
+++ b/teaser/examples/e2_export_aixlib_models.py
@@ -1,5 +1,4 @@
 # # Example 2: Export Modelica models for AixLib library using TEASER API
-
 # This module contains an example how to export buildings from a TEASER
 # project to ready-to-run simulation models for Modelica library AixLib.
 # AixLib focuses on ideal hat demand calculation. In contrast,

--- a/teaser/examples/e3_export_ibpsa_models.py
+++ b/teaser/examples/e3_export_ibpsa_models.py
@@ -5,7 +5,7 @@
 # IBPSA focuses on free floating temperature without an ideal heater.
 # In contrast, AixLib focuses on ideal heat demand calculation, and
 # BESMod on the coupling to state-of-the-art energy systems.
-# These models simulate in Dymola, OpenModelica and JModelica.
+# These models should simulate in Dymola, OpenModelica and JModelica.
 # You can run this example using the [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/main?labpath=docs%2Fjupyter_notebooks)
 
 import teaser.examples.e1_generate_archetype as e1

--- a/teaser/examples/e3_export_ibpsa_models.py
+++ b/teaser/examples/e3_export_ibpsa_models.py
@@ -1,5 +1,4 @@
 # # Example 3: Export Modelica models for IBPSA library using TEASER API
-
 # This module contains an example how to export buildings from a TEASER
 # project to ready-to-run simulation models for Modelica library IBPSA.
 # IBPSA focuses on free floating temperature without an ideal heater.

--- a/teaser/examples/e3_export_ibpsa_models.py
+++ b/teaser/examples/e3_export_ibpsa_models.py
@@ -1,7 +1,11 @@
 # # Example 3: Export Modelica models for IBPSA library using TEASER API
+
 # This module contains an example how to export buildings from a TEASER
-# project to ready-to-run simulation models for Modelica library IBPSA. These
-# models simulate in Dymola, OpenModelica and JModelica.
+# project to ready-to-run simulation models for Modelica library IBPSA.
+# IBPSA focuses on free floating temperature without an ideal heater.
+# In contrast, AixLib focuses on ideal heat demand calculation, and
+# BESMod on the coupling to state-of-the-art energy systems.
+# These models simulate in Dymola, OpenModelica and JModelica.
 # You can run this example using the [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/main?labpath=docs%2Fjupyter_notebooks)
 
 import teaser.examples.e1_generate_archetype as e1

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -51,7 +51,7 @@ def example_export_besmod():
             "input",
             "inputdata",
             "weatherdata",
-            "DEU_BW_Mannheim_107290_TRY2010_12_Jahr_BBSR.mos"))  # ToDo fwu-hst: add to export (look at AixLib export)
+            "DEU_BW_Mannheim_107290_TRY2010_12_Jahr_BBSR.mos"))
 
     # To make sure the parameters are calculated correctly we recommend to
     # run calc_all_buildings() function
@@ -98,7 +98,7 @@ def example_export_besmod():
         QBuiOld_flow_design[bldg.name] = {}
         for tz in bldg.thermal_zones:
             QBuiOld_flow_design[bldg.name][tz.name] = tz.model_attr.heat_load
-    # ToDo fwu-hst: set t_outside for heat_load calculation?
+
     prj.name = "ArchetypeExample_partial_retrofit"
 
     prj.retrofit_all_buildings(

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -78,7 +78,7 @@ def example_export_besmod():
     }
 
     examples = ["TEASERHeatLoadCalculation",
-                "ModelicaConferencePaper",
+                "HeatPumpMonoenergetic",
                 "GasBoilerBuildingOnly"]
 
     path = prj.export_besmod(

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -1,9 +1,7 @@
 # # Example 2: Export Modelica models for AixLib library using TEASER API
 
 # This module contains an example how to export buildings from a TEASER
-# project to ready-to-run simulation models for Modelica library AixLib. These
-# models will only simulate using Dymola, the reason for this are state
-# machines that are used in one AixLib specific AHU model.
+# project to ready-to-run simulation models for Modelica library BESMod.
 # You can run this example using the [jupyter-notebook](https://mybinder.org/v2/gh/RWTH-EBC/TEASER/master?labpath=docs%2Fjupyter_notebooks)
 
 import teaser.examples.e1_generate_archetype as e1
@@ -20,19 +18,6 @@ def example_export_besmod():
 
     prj = e1.example_generate_archetype()
 
-    # To make sure the export is using the desired parameters you should
-    # always set model settings in the Project.
-    # Project().used_library_calc specifies the used Modelica library
-    # Project().number_of_elements_calc sets the models order
-    # For more information on models we'd like to refer you to the docs. By
-    # default TEASER uses a weather file provided in
-    # teaser.data.input.inputdata.weatherdata. You can use your own weather
-    # file by setting Project().weather_file_path. However we will use default
-    # weather file.
-    # Be careful: Dymola does not like whitespaces in names and filenames,
-    # thus we will delete them anyway in TEASER.
-
-    # for CI testing purpose we set the reference result folder
 
     prj.dir_reference_results = utilities.get_full_path(
         os.path.join(
@@ -61,8 +46,6 @@ def example_export_besmod():
             "weatherdata",
             "DEU_BW_Mannheim_107290_TRY2010_12_Jahr_BBSR.mos"))
 
-    # To make sure the parameters are calculated correctly we recommend to
-    # run calc_all_buildings() function
 
     prj.set_location_parameters(t_outside=262.65,
                                 t_ground=286.15,
@@ -70,14 +53,6 @@ def example_export_besmod():
                                 calc_all_buildings=True)
 
     # prj.calc_all_buildings()
-
-    # To export the ready-to-run models simply call Project.export_aixlib().
-    # You can specify the path, where the model files should be saved.
-    # None means, that the default path in your home directory
-    # will be used. If you only want to export one specific building, you can
-    # pass over the internal_id of that building and only this model will be
-    # exported. In this case we want to export all buildings to our home
-    # directory, thus we are passing over None for both parameters.
 
     examples = ["TEASERHeatLoadCalculation",
                 "HeatPumpMonoenergetic",
@@ -134,11 +109,17 @@ def example_export_besmod():
 
     prj.name = "ArchetypeExample_total_retrofit"
 
+    custom_template = {"ModelicaConferencePaper": r"D:\fwu-hst\00_temp\custom_template.txt"}
+    custom_script = {"HeatPumpMonoenergetic": r"D:\fwu-hst\00_temp\custom_script_hp_mono.txt",
+                     "ModelicaConferencePaper": r"D:\fwu-hst\00_temp\custom_script.txt"}
+
     path = prj.export_besmod(
         THydSup_nominal=THydSup_nominal,
         internal_id=None,
         path=r"D:\fwu-hst\TEASEROutput_besmod",
         examples=examples,
+        custom_examples=custom_template,
+        custom_script=custom_script,
         report=True
     )
 

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -92,7 +92,7 @@ def example_export_besmod():
     for bldg in prj.buildings:
         QBuiOld_flow_design[bldg.name] = {}
         for tz in bldg.thermal_zones:
-            QBuiOld_flow_design[bldg.name][tz.name] = tz.model_attr.heat_load # ToDo fwu-hst: calculation with infiltration rate 0.2 instead of 0.5 as in BESMod
+            QBuiOld_flow_design[bldg.name][tz.name] = tz.model_attr.heat_load
     # ToDo fwu-hst: set t_outside for heat_load calculation?
     prj.name = "ArchetypeExample_partial_retrofit"
 

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -45,7 +45,7 @@ def example_export_besmod():
 
     prj.used_library_calc = 'AixLib'  # ToDo fwu-hst: Always AixLib? If true, put it in explicit in besmod_output
     prj.number_of_elements_calc = 4
-    prj.weather_file_path = utilities.get_full_path(
+    weather_file_path = utilities.get_full_path(
         os.path.join(
             "data",
             "input",
@@ -56,7 +56,12 @@ def example_export_besmod():
     # To make sure the parameters are calculated correctly we recommend to
     # run calc_all_buildings() function
 
-    prj.calc_all_buildings()
+    prj.set_location_parameters(t_outside=262.65,
+                                t_ground=286.15,
+                                weather_file_path=weather_file_path,
+                                calc_all_buildings=True)
+
+    # prj.calc_all_buildings()
 
     # To export the ready-to-run models simply call Project.export_aixlib().
     # You can specify the path, where the model files should be saved.

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -45,6 +45,14 @@ def example_export_besmod():
 
     prj.used_library_calc = 'AixLib'
     prj.number_of_elements_calc = 4
+
+    Residential = [
+        bldg for bldg in prj.buildings if bldg.name == "ResidentialBuilding"][0]
+
+    Residential.thermal_zones[0].use_conditions.set_back_times = [5, 22]
+    Residential.thermal_zones[0].use_conditions.heating_set_back = -3
+    # Residential.thermal_zones[0].use_conditions.calc_adj_schedules()
+
     weather_file_path = utilities.get_full_path(
         os.path.join(
             "data",

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -43,7 +43,7 @@ def example_export_besmod():
 
     print(prj.dir_reference_results)
 
-    prj.used_library_calc = 'AixLib'  # ToDo fwu-hst: Always AixLib? If true, put it in explicit in besmod_output
+    prj.used_library_calc = 'AixLib'
     prj.number_of_elements_calc = 4
     weather_file_path = utilities.get_full_path(
         os.path.join(

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -1,4 +1,4 @@
-# # Example 2: Export Modelica models for AixLib library using TEASER API
+# # Example 4: Export Modelica models for BESMod library using TEASER API
 
 # This module contains an example how to export buildings from a TEASER
 # project to ready-to-run simulation models for Modelica library BESMod.
@@ -9,8 +9,8 @@ import teaser.logic.utilities as utilities
 import os
 
 
-def example_export_besmod():
-    """This function demonstrates the export to Modelica library AixLib using
+def example_export_besmod(save_dir_path=None):
+    """This function demonstrates the export to Modelica library BESMod using
     the API function of TEASER"""
 
     # In e1_generate_archetype we created a Project with three archetype
@@ -18,48 +18,32 @@ def example_export_besmod():
 
     prj = e1.example_generate_archetype()
 
-
-    prj.dir_reference_results = utilities.get_full_path(
-        os.path.join(
-            "examples",
-            "examplefiles",
-            "ReferenceResults",
-            "Dymola"))
-
-    print(prj.dir_reference_results)
+    # To make sure the export is using the desired parameters you should
+    # always set model settings in the Project.
+    # The TEASER building in BESMod uses the AixLib.ThermalZones.ReducedOrder.ThermalZone.ThermalZone model
+    # with 4 elements, so we have to set these project settings
 
     prj.used_library_calc = 'AixLib'
     prj.number_of_elements_calc = 4
 
-    Residential = [
-        bldg for bldg in prj.buildings if bldg.name == "ResidentialBuilding"][0]
-
-    Residential.thermal_zones[0].use_conditions.set_back_times = [5, 22]
-    Residential.thermal_zones[0].use_conditions.heating_set_back = -3
-    # Residential.thermal_zones[0].use_conditions.calc_adj_schedules()
-
-    weather_file_path = utilities.get_full_path(
-        os.path.join(
-            "data",
-            "input",
-            "inputdata",
-            "weatherdata",
-            "DEU_BW_Mannheim_107290_TRY2010_12_Jahr_BBSR.mos"))
-
-
-    prj.set_location_parameters(t_outside=262.65,
-                                t_ground=286.15,
-                                weather_file_path=weather_file_path,
-                                calc_all_buildings=True)
-
-    # prj.calc_all_buildings()
+    # With these information we could already export the building models
+    # which extend from BESMod.Systems.Demand.Building.TEASERThermalZone.
+    # But we have also the option to include these building models directly in
+    # predefined example building energy systems. These systems are:
+    # "TEASERHeatLoadCalculation" which is a system with an ideal electric heater for heat load calculation.
+    # "HeatPumpMonoenergetic" which is a system with a heat pump and an electric heater in serial,
+    # buffer and DHW storages, radiators and PV.
+    # "GasBoilerBuildingOnly" which is a system with a gas boiler and radiators.
 
     examples = ["TEASERHeatLoadCalculation",
                 "HeatPumpMonoenergetic",
                 "GasBoilerBuildingOnly"]
 
+    # For the examples with hydraulic system, we need further parameters to get fully parameterized ready to run model.
+    # This is manly the nominal hydraulic supply temperature. We have different options to set this value.
+    # First, we can set one value for all buildings and thermal zones in the project.
     THydSup_nominal = 55 + 273.15
-    THydSup_nominal = {1950: 90+273.15, 1980: 70+273.15, 2010: 55+273.15, 2024: 35+273.15}
+    # Second, we can set the value separately for each building and with in the building also for each thermal zone.
     THydSup_nominal = {"ResidentialBuilding": 328.15,
                        "OfficeBuilding": 328.15,
                        "InstituteBuilding": {"Office": 343.15,
@@ -72,15 +56,45 @@ def example_export_besmod():
                        "InstituteBuildingMoisture": 343.15,
                        "ResidentialBuildingTabula": 328.15,
                        "ResidentialBuildingTabulaMulti": 328.15}
+    # Third, we can specify the value for a building by the construction year. Here the value of the next higher
+    # specified year is set to the building. The classification here is taken from
+    # https://www.ffe.de/projekte/waermepumpen-fahrplan-finanzielle-kipppunkte-zur-modernisierung-mit-waermepumpen-im-wohngebaeudebestand/
+    THydSup_nominal = {1950: 90 + 273.15, 1980: 70 + 273.15, 2010: 55 + 273.15, 2024: 35 + 273.15}
 
+    # The parameters for the BESMod.Systems.UserProfiles.TEASERProfiles are also set in the export of
+    # the examples. The internal gains file which is exported with the building is set and heating set backs
+    # are extracted from the heating_profile of each zone and directly set in the setBakTSetZone Pulse block.
+    # BESMod only allows 24 hours heating profiles.
+
+    # We also need to set location specific parameters which we can do with the following function.
+    # The values we set here are the default values which correspond to Mannheim.
+
+    weather_file_path = utilities.get_full_path(
+        os.path.join(
+            "data",
+            "input",
+            "inputdata",
+            "weatherdata",
+            "DEU_BW_Mannheim_107290_TRY2010_12_Jahr_BBSR.mos"))
+
+    prj.set_location_parameters(t_outside=262.65,
+                                t_ground=286.15,
+                                weather_file_path=weather_file_path,
+                                calc_all_buildings=True)
+
+    # To make sure the parameters are calculated correctly we recommend to
+    # run prj.calc_all_buildings() function which is here already done in the set_location_parameters function
+
+    # Now we export all building in the project and also include it in all optional examples.
     path = prj.export_besmod(
         THydSup_nominal=THydSup_nominal,
-        internal_id=None,
-        path=r"D:\fwu-hst\TEASEROutput_besmod",
-        examples=examples,
-        report=True
+        path=save_dir_path,
+        examples=examples
     )
 
+    # We can also utilize the partial retrofit option of the energy system in BESMod.
+    # For that we need to extract the nominal heat flow of each zone in the building
+    # and then retrofit the buildings here in TEASER.
 
     QBuiOld_flow_design = {}
     for bldg in prj.buildings:
@@ -89,45 +103,57 @@ def example_export_besmod():
             QBuiOld_flow_design[bldg.name][tz.name] = tz.model_attr.heat_load
 
     prj.name = "ArchetypeExample_partial_retrofit"
-
     prj.retrofit_all_buildings(
         year_of_retrofit=2015,
         type_of_retrofit="adv_retrofit",
         window_type='Alu- oder Stahlfenster, Isolierverglasung',
-        material='EPS_perimeter_insulation_top_layer')
-
+        material='EPS_perimeter_insulation_top_layer'
+    )
     prj.calc_all_buildings()
+
+    # When we now set heat flow of the old building design.
+    # By default, the radiator transfer systems are not retrofitted when the
+    # QBuiOld_flow_design parameter is set and different to the new nominal heat flow.
+    # We would also have the option to set new THycSup_nominal temperatures and set
+    # the old temperatures with THydSupOld_design which are used for the sizing of the radiators
+    # but not in the controls.
 
     path = prj.export_besmod(
         THydSup_nominal=THydSup_nominal,
         QBuiOld_flow_design=QBuiOld_flow_design,
-        internal_id=None,
-        path=r"D:\fwu-hst\TEASEROutput_besmod",
-        examples=examples,
-        report=True
+        path=save_dir_path,
+        examples=examples
     )
+
+    # If QBuiOld_flow_design is not set the energy system is also totally retrofitted to the new heat demand.
+    # We have also the option to define custom templates into which the building should be included.
+    # For example, we have here a custom template where the building is included in the
+    # ModelicaConferencePaper example in BESMod which als includes a battery.
 
     prj.name = "ArchetypeExample_total_retrofit"
 
-    custom_template = {"ModelicaConferencePaper": r"D:\fwu-hst\00_temp\custom_template.txt"}
-    custom_script = {"HeatPumpMonoenergetic": r"D:\fwu-hst\00_temp\custom_script_hp_mono.txt",
-                     "ModelicaConferencePaper": r"D:\fwu-hst\00_temp\custom_script.txt"}
+    custom_template_path = os.path.join(
+        os.path.dirname(__file__), "examplefiles", "custom_besmod_templates"
+    )
+    custom_example_template = {"ModelicaConferencePaper": os.path.join(custom_template_path,"custom_template.txt")}
 
+    # Also .mos scripts can be generated with a template and exported together with the model.
+    # For the existing examples a basic simulate and plot .mos script is exported
+
+    custom_script = {"HeatPumpMonoenergetic": os.path.join(custom_template_path,"custom_script_hp_mono.txt"),
+                     "ModelicaConferencePaper": os.path.join(custom_template_path,"custom_script.txt")}
     path = prj.export_besmod(
         THydSup_nominal=THydSup_nominal,
-        internal_id=None,
-        path=r"D:\fwu-hst\TEASEROutput_besmod",
+        path=save_dir_path,
         examples=examples,
-        custom_examples=custom_template,
-        custom_script=custom_script,
-        report=True
+        custom_examples=custom_example_template,
+        custom_script=custom_script
     )
 
     return path
 
 
 if __name__ == '__main__':
+    example_export_besmod(save_dir_path=r"D:\fwu-hst\TEASEROutput_besmod")
 
-    example_export_besmod()
-
-    print("Example 2: That's it! :)")
+    print("Example 4: That's it! :)")

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -51,7 +51,7 @@ def example_export_besmod():
             "input",
             "inputdata",
             "weatherdata",
-            "DEU_BW_Mannheim_107290_TRY2010_12_Jahr_BBSR.mos"))  # ToDo fwu-hst: Check if relevant for besmod
+            "DEU_BW_Mannheim_107290_TRY2010_12_Jahr_BBSR.mos"))  # ToDo fwu-hst: add to export (look at AixLib export)
 
     # To make sure the parameters are calculated correctly we recommend to
     # run calc_all_buildings() function
@@ -93,7 +93,7 @@ def example_export_besmod():
         QBuiOld_flow_design[bldg.name] = {}
         for tz in bldg.thermal_zones:
             QBuiOld_flow_design[bldg.name][tz.name] = tz.model_attr.heat_load # ToDo fwu-hst: calculation with infiltration rate 0.2 instead of 0.5 as in BESMod
-
+    # ToDo fwu-hst: set t_outside for heat_load calculation?
     prj.name = "ArchetypeExample_partial_retrofit"
 
     prj.retrofit_all_buildings(

--- a/teaser/examples/e4_export_besmod_models.py
+++ b/teaser/examples/e4_export_besmod_models.py
@@ -79,7 +79,13 @@ def example_export_besmod():
     THydSup_nominal = {1950: 90+273.15, 1980: 70+273.15, 2010: 55+273.15, 2024: 35+273.15}
     THydSup_nominal = {"ResidentialBuilding": 328.15,
                        "OfficeBuilding": 328.15,
-                       "InstituteBuilding": 343.15,
+                       "InstituteBuilding": {"Office": 343.15,
+                                             "Floor": 343.15,
+                                             "Storage": 343.15,
+                                             "Meeting": 343.15,
+                                             "Restroom": 343.15,
+                                             "ICT": 343.15,
+                                             "Laboratory": 328.15},
                        "InstituteBuildingMoisture": 343.15,
                        "ResidentialBuildingTabula": 328.15,
                        "ResidentialBuildingTabulaMulti": 328.15}

--- a/teaser/examples/e6_generate_building.py
+++ b/teaser/examples/e6_generate_building.py
@@ -52,7 +52,6 @@ def example_create_building():
     tz.name = "LivingRoom"
     tz.area = 140.0
     tz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors
-    tz.infiltration_rate = 0.5
 
     # Instantiate BoundaryConditions and load conditions for `Living`.
 

--- a/teaser/examples/examplefiles/ASHRAE140_600.json
+++ b/teaser/examples/examplefiles/ASHRAE140_600.json
@@ -63,7 +63,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.5,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/examplefiles/ASHRAE140_620.json
+++ b/teaser/examples/examplefiles/ASHRAE140_620.json
@@ -64,7 +64,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.5,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/examplefiles/ASHRAE140_900.json
+++ b/teaser/examples/examplefiles/ASHRAE140_900.json
@@ -63,7 +63,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.5,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/examplefiles/ASHRAE140_920.json
+++ b/teaser/examples/examplefiles/ASHRAE140_920.json
@@ -64,7 +64,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.5,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/examplefiles/VDI6007_Room1.json
+++ b/teaser/examples/examplefiles/VDI6007_Room1.json
@@ -59,7 +59,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.5,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/examplefiles/VDI6007_Room10.json
+++ b/teaser/examples/examplefiles/VDI6007_Room10.json
@@ -60,7 +60,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.5,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/examplefiles/VDI6007_Room3.json
+++ b/teaser/examples/examplefiles/VDI6007_Room3.json
@@ -59,7 +59,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.5,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/examplefiles/VDI6007_Room8.json
+++ b/teaser/examples/examplefiles/VDI6007_Room8.json
@@ -61,7 +61,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.5,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/examplefiles/custom_besmod_templates/custom_script.txt
+++ b/teaser/examples/examplefiles/custom_besmod_templates/custom_script.txt
@@ -1,0 +1,4 @@
+simulateModel("${project.name}.${bldg.name}.ModelicaConferencePaper${bldg.name}", stopTime=864000, method="dassl", tolerance=1e-06, resultFile="ModelicaConferencePaper${bldg.name}");
+createPlot(id=2, position={75, 70, 1210, 240}, y={"electrical.distribution.batterySimple.PLoad","electrical.distribution.batterySimple.PCharge"}, grid=true, subPlot=1, colors={{28,108,200},{238,46,47}});
+createPlot(id=2, position={75, 70, 1210, 240}, y={"hydraulic.distribution.sigBusDistr.TStoDHWTopMea","hydraulic.distribution.sigBusDistr.TStoBufTopMea","hydraulic.generation.sigBusGen.TGenOutMea"}, grid=true, subPlot=2, colors={{28,108,200},{238,46,47},{0,140,72}});
+createPlot(id=2, position={75, 70, 1210, 240}, y={"ventilation.generation.TSup.T","ventilation.generation.weaBus.TDryBul","building.buiMeaBus.TZoneMea[1]"}, grid=true, subPlot=3, colors={{28,108,200},{238,46,47},{0,140,72}});

--- a/teaser/examples/examplefiles/custom_besmod_templates/custom_script_hp_mono.txt
+++ b/teaser/examples/examplefiles/custom_besmod_templates/custom_script_hp_mono.txt
@@ -1,0 +1,4 @@
+simulateModel("${project.name}.${bldg.name}.HeatPumpMonoenergetic${bldg.name}", stopTime=864000, method="dassl", tolerance=1e-06, resultFile="ModelicaConferencePaper${bldg.name}");
+createPlot(id=2, position={75, 70, 1210, 240}, y={"electrical.distribution.batterySimple.PLoad","electrical.distribution.batterySimple.PCharge"}, grid=true, subPlot=1, colors={{28,108,200},{238,46,47}});
+createPlot(id=2, position={75, 70, 1210, 240}, y={"hydraulic.distribution.sigBusDistr.TStoDHWTopMea","hydraulic.distribution.sigBusDistr.TStoBufTopMea","hydraulic.generation.sigBusGen.TGenOutMea"}, grid=true, subPlot=2, colors={{28,108,200},{238,46,47},{0,140,72}});
+createPlot(id=2, position={75, 70, 1210, 240}, y={"ventilation.generation.TSup.T","ventilation.generation.weaBus.TDryBul","building.buiMeaBus.TZoneMea[1]"}, grid=true, subPlot=3, colors={{28,108,200},{238,46,47},{0,140,72}});

--- a/teaser/examples/examplefiles/custom_besmod_templates/custom_template.txt
+++ b/teaser/examples/examplefiles/custom_besmod_templates/custom_template.txt
@@ -18,6 +18,8 @@ model ModelicaConferencePaper${bldg.name}
                      THydSupOld_design=${THydSupOld_design},
                      filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
 
+  extends Modelica.Icons.Example;
+
   annotation (experiment(StopTime=172800,
      Interval=600,
      Tolerance=1e-06),

--- a/teaser/examples/examplefiles/custom_besmod_templates/custom_template.txt
+++ b/teaser/examples/examplefiles/custom_besmod_templates/custom_template.txt
@@ -1,0 +1,28 @@
+<%namespace file="/modelica_language/" import="get_list"/>
+within ${bldg.parent.name}.${bldg.name};
+model ModelicaConferencePaper${bldg.name}
+  extends BESMod.Examples.ModelicaConferencePaper.PartialModelicaConferenceUseCase(
+    redeclare ${bldg.name} building,
+    redeclare BESMod.Systems.UserProfiles.TEASERProfiles userProfiles(fileNameIntGains=Modelica.Utilities.Files.loadResource(
+        "modelica://${bldg.parent.name}/${bldg.name}/InternalGains_${bldg.name}.txt"),
+        setBakTSetZone(
+            amplitude=${get_list(setBakTSetZone_amplitude)},
+            width=${get_list(setBakTSetZone_width)},
+            startTime=${get_list(setBakTSetZone_startTime)})),
+    systemParameters(nZones=${len(bldg.thermal_zones)},
+		     QBui_flow_nominal=building.QRec_flow_nominal,
+                     TOda_nominal=${TOda_nominal},
+		     TSetZone_nominal=${get_list(TSetZone_nominal)},
+                     THydSup_nominal=${THydSup_nominal},
+                     QBuiOld_flow_design=${QBuiOld_flow_design},
+                     THydSupOld_design=${THydSupOld_design},
+                     filNamWea=Modelica.Utilities.Files.loadResource("modelica://${bldg.parent.name}/Resources/${bldg.parent.weather_file_name}")));
+
+  annotation (experiment(StopTime=172800,
+     Interval=600,
+     Tolerance=1e-06),
+   __Dymola_Commands(file=
+        "Resources/Scripts/Dymola/${bldg.name}/ModelicaConferencePaper${bldg.name}.mos"
+        "Simulate and plot"));
+
+end ModelicaConferencePaper${bldg.name};

--- a/teaser/examples/examplefiles/unitTest.json
+++ b/teaser/examples/examplefiles/unitTest.json
@@ -47,7 +47,7 @@
                     "Office": {
                         "area": 994.0,
                         "volume": 994.0,
-                        "infiltration_rate": null,
+                        "base_infiltration": null,
                         "typical_length": 6.0,
                         "typical_width": 6.0,
                         "use_conditions": {
@@ -71,7 +71,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.9,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,
@@ -785,7 +785,7 @@
                     "Floor": {
                         "area": 497.0,
                         "volume": 497.0,
-                        "infiltration_rate": null,
+                        "base_infiltration": null,
                         "typical_length": 2.0,
                         "typical_width": 12.0,
                         "use_conditions": {
@@ -809,7 +809,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.9,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,
@@ -1523,7 +1523,7 @@
                     "Storage": {
                         "area": 298.2,
                         "volume": 298.2,
-                        "infiltration_rate": null,
+                        "base_infiltration": null,
                         "typical_length": 6.0,
                         "typical_width": 6.0,
                         "use_conditions": {
@@ -1547,7 +1547,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.9,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,
@@ -2261,7 +2261,7 @@
                     "Meeting": {
                         "area": 79.52,
                         "volume": 79.52,
-                        "infiltration_rate": null,
+                        "base_infiltration": null,
                         "typical_length": 6.0,
                         "typical_width": 6.0,
                         "use_conditions": {
@@ -2285,7 +2285,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.9,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,
@@ -2999,7 +2999,7 @@
                     "Restroom": {
                         "area": 79.52,
                         "volume": 79.52,
-                        "infiltration_rate": null,
+                        "base_infiltration": null,
                         "typical_length": 3.0,
                         "typical_width": 6.0,
                         "use_conditions": {
@@ -3023,7 +3023,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.9,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,
@@ -3737,7 +3737,7 @@
                     "ICT": {
                         "area": 39.76,
                         "volume": 39.76,
-                        "infiltration_rate": null,
+                        "base_infiltration": null,
                         "typical_length": 6.0,
                         "typical_width": 6.0,
                         "use_conditions": {
@@ -3761,7 +3761,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.9,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/examplefiles/unitTestCalc.json
+++ b/teaser/examples/examplefiles/unitTestCalc.json
@@ -67,7 +67,7 @@
                             "lighting_efficiency_lumen": 150,
                             "ratio_conv_rad_lighting": 0.5,
                             "use_constant_infiltration": false,
-                            "infiltration_rate": 0.2,
+                            "base_infiltration": 0.2,
                             "max_user_infiltration": 1.0,
                             "max_overheating_infiltration": [
                                 3.0,

--- a/teaser/examples/verification/verification_ASHRAE_140_600.py
+++ b/teaser/examples/verification/verification_ASHRAE_140_600.py
@@ -77,7 +77,7 @@ def from_scratch(number_of_elements, save=False, path=utilities.get_default_path
     tz.volume = tz.area * 2.7
 
     tz.use_conditions = UseConditions(parent=tz)
-    tz.use_conditions.infiltration_rate = 0.41
+    tz.use_conditions.base_infiltration = 0.41
 
     roof = Rooftop(parent=tz)
     roof.name = "Roof"

--- a/teaser/examples/verification/verification_ASHRAE_140_620.py
+++ b/teaser/examples/verification/verification_ASHRAE_140_620.py
@@ -77,7 +77,7 @@ def from_scratch(number_of_elements, save=False, path=utilities.get_default_path
     tz.area = 8.0 * 6.0
     tz.volume = tz.area * 2.7
     tz.use_conditions = UseConditions(parent=tz)
-    tz.use_conditions.infiltration_rate = 0.41
+    tz.use_conditions.base_infiltration = 0.41
 
     roof = Rooftop(parent=tz)
     roof.name = "Roof"

--- a/teaser/examples/verification/verification_ASHRAE_140_900.py
+++ b/teaser/examples/verification/verification_ASHRAE_140_900.py
@@ -76,7 +76,7 @@ def from_scratch(number_of_elements, save=False, path=utilities.get_default_path
     tz.area = 8.0 * 6.0
     tz.volume = tz.area * 2.7
     tz.use_conditions = UseConditions(parent=tz)
-    tz.use_conditions.infiltration_rate = 0.41
+    tz.use_conditions.base_infiltration = 0.41
 
     roof = Rooftop(parent=tz)
     roof.name = "Roof"

--- a/teaser/examples/verification/verification_ASHRAE_140_920.py
+++ b/teaser/examples/verification/verification_ASHRAE_140_920.py
@@ -76,7 +76,7 @@ def from_scratch(number_of_elements, save=False, path=utilities.get_default_path
     tz.area = 8.0 * 6.0
     tz.volume = tz.area * 2.7
     tz.use_conditions = UseConditions(parent=tz)
-    tz.use_conditions.infiltration_rate = 0.41
+    tz.use_conditions.base_infiltration = 0.41
 
     roof = Rooftop(parent=tz)
     roof.name = "Roof"

--- a/teaser/logic/buildingobjects/building.py
+++ b/teaser/logic/buildingobjects/building.py
@@ -93,6 +93,10 @@ class Building(object):
         that direction as value.
     bldg_height : float [m]
         Total building height.
+    area_rt : float [m2]
+        Total roof area of all thermal zones.
+    area_gf : float [m2]
+        Total ground floor area of all thermal zones.
     volume : float [m3]
         Total volume of all thermal zones.
     sum_heat_load : float [W]

--- a/teaser/logic/buildingobjects/calculation/aixlib.py
+++ b/teaser/logic/buildingobjects/calculation/aixlib.py
@@ -64,8 +64,8 @@ class AixLib(object):
         self.file_set_t_cool = "TsetCool_" + self.parent.name + ".txt"
         self.file_ahu = "AHU_" + self.parent.name + ".txt"
         self.file_internal_gains = "InternalGains_" + self.parent.name + ".txt"
-        self.version = "2.1.0"
-        self.besmod_version = "0.5.0"
+        self.version = "2.2.0"
+        self.besmod_version = "0.6.0"
         self.total_surface_area = None
         self.consider_heat_capacity = True
         self.use_set_back = True

--- a/teaser/logic/buildingobjects/calculation/aixlib.py
+++ b/teaser/logic/buildingobjects/calculation/aixlib.py
@@ -64,7 +64,7 @@ class AixLib(object):
         self.file_set_t_cool = "TsetCool_" + self.parent.name + ".txt"
         self.file_ahu = "AHU_" + self.parent.name + ".txt"
         self.file_internal_gains = "InternalGains_" + self.parent.name + ".txt"
-        self.version = "2.2.0"
+        self.version = "2.1.1"
         self.besmod_version = "0.6.0"
         self.total_surface_area = None
         self.consider_heat_capacity = True

--- a/teaser/logic/buildingobjects/calculation/aixlib.py
+++ b/teaser/logic/buildingobjects/calculation/aixlib.py
@@ -32,6 +32,9 @@ class AixLib(object):
     version : str
         Used AixLib version, default should always be current master version
         of GitHub
+    besmod_version : str
+        Used BESMod version vor export_besmod, default should always be current main version
+        of GitHub
     total_surface_area : float [m2]
         This is the total surface area of the building for interior and
         exterior surfaces. That includes: OuterWalls, Rooftops, GroundFloors,
@@ -62,6 +65,7 @@ class AixLib(object):
         self.file_ahu = "AHU_" + self.parent.name + ".txt"
         self.file_internal_gains = "InternalGains_" + self.parent.name + ".txt"
         self.version = "2.1.0"
+        self.besmod_version = "0.5.0"
         self.total_surface_area = None
         self.consider_heat_capacity = True
         self.use_set_back = True

--- a/teaser/logic/buildingobjects/calculation/four_element.py
+++ b/teaser/logic/buildingobjects/calculation/four_element.py
@@ -1555,7 +1555,7 @@ class FourElement(object):
         self.heat_load_outside_factor = (
             (ua_value_ow_temp + self.ua_value_win)
             + self.thermal_zone.volume
-            * self.thermal_zone.use_conditions.static_infiltration
+            * self.thermal_zone.use_conditions.normative_infiltration
             * 1
             / 3600
             * self.thermal_zone.heat_capac_air

--- a/teaser/logic/buildingobjects/calculation/four_element.py
+++ b/teaser/logic/buildingobjects/calculation/four_element.py
@@ -1549,6 +1549,10 @@ class FourElement(object):
         ua_value_gf_temp : float [W/(m2*K)]
             UA Value of all GroundFloors
         """
+        if self.thermal_zone.use_condition.base_infiltration > 0.5:
+            raise warnings.warn("The base_infiltration is larger than 0.5, "
+                                "which could lead to ideal heaters being too small.")
+
         self.heat_load = 0.0
 
         ua_value_ow_temp = self.ua_value_rt + self.ua_value_ow

--- a/teaser/logic/buildingobjects/calculation/four_element.py
+++ b/teaser/logic/buildingobjects/calculation/four_element.py
@@ -1555,7 +1555,7 @@ class FourElement(object):
         self.heat_load_outside_factor = (
             (ua_value_ow_temp + self.ua_value_win)
             + self.thermal_zone.volume
-            * self.thermal_zone.use_conditions.infiltration_rate
+            * self.thermal_zone.use_conditions.static_infiltration
             * 1
             / 3600
             * self.thermal_zone.heat_capac_air

--- a/teaser/logic/buildingobjects/calculation/four_element.py
+++ b/teaser/logic/buildingobjects/calculation/four_element.py
@@ -1549,7 +1549,7 @@ class FourElement(object):
         ua_value_gf_temp : float [W/(m2*K)]
             UA Value of all GroundFloors
         """
-        if self.thermal_zone.use_condition.base_infiltration > 0.5:
+        if self.thermal_zone.use_conditions.base_infiltration > 0.5:
             raise warnings.warn("The base_infiltration is larger than 0.5, "
                                 "which could lead to ideal heaters being too small.")
 

--- a/teaser/logic/buildingobjects/calculation/one_element.py
+++ b/teaser/logic/buildingobjects/calculation/one_element.py
@@ -979,7 +979,7 @@ class OneElement(object):
         ua_value_gf_temp : float [W/(m2*K)]
             UA Value of all GroundFloors
         """
-        if self.thermal_zone.use_condition.base_infiltration > 0.5:
+        if self.thermal_zone.use_conditions.base_infiltration > 0.5:
             raise warnings.warn("The base_infiltration is larger than 0.5, "
                                 "which could lead to ideal heaters being too small.")
 

--- a/teaser/logic/buildingobjects/calculation/one_element.py
+++ b/teaser/logic/buildingobjects/calculation/one_element.py
@@ -987,7 +987,7 @@ class OneElement(object):
         self.heat_load_outside_factor = (
             (ua_value_ow_temp + self.ua_value_win)
             + self.thermal_zone.volume
-            * self.thermal_zone.use_conditions.infiltration_rate
+            * self.thermal_zone.use_conditions.static_infiltration
             * 1
             / 3600
             * self.thermal_zone.heat_capac_air

--- a/teaser/logic/buildingobjects/calculation/one_element.py
+++ b/teaser/logic/buildingobjects/calculation/one_element.py
@@ -979,6 +979,10 @@ class OneElement(object):
         ua_value_gf_temp : float [W/(m2*K)]
             UA Value of all GroundFloors
         """
+        if self.thermal_zone.use_condition.base_infiltration > 0.5:
+            raise warnings.warn("The base_infiltration is larger than 0.5, "
+                                "which could lead to ideal heaters being too small.")
+
         self.heat_load = 0.0
         ua_value_gf_temp = sum(
             ground.ua_value for ground in self.thermal_zone.ground_floors

--- a/teaser/logic/buildingobjects/calculation/one_element.py
+++ b/teaser/logic/buildingobjects/calculation/one_element.py
@@ -987,7 +987,7 @@ class OneElement(object):
         self.heat_load_outside_factor = (
             (ua_value_ow_temp + self.ua_value_win)
             + self.thermal_zone.volume
-            * self.thermal_zone.use_conditions.static_infiltration
+            * self.thermal_zone.use_conditions.normative_infiltration
             * 1
             / 3600
             * self.thermal_zone.heat_capac_air

--- a/teaser/logic/buildingobjects/calculation/three_element.py
+++ b/teaser/logic/buildingobjects/calculation/three_element.py
@@ -1287,7 +1287,7 @@ class ThreeElement(object):
         self.heat_load_outside_factor = (
             (ua_value_ow_temp + self.ua_value_win)
             + self.thermal_zone.volume
-            * self.thermal_zone.use_conditions.infiltration_rate
+            * self.thermal_zone.use_conditions.static_infiltration
             * 1
             / 3600
             * self.thermal_zone.heat_capac_air

--- a/teaser/logic/buildingobjects/calculation/three_element.py
+++ b/teaser/logic/buildingobjects/calculation/three_element.py
@@ -1282,7 +1282,7 @@ class ThreeElement(object):
         ua_value_gf_temp : float [W/(m2*K)]
             UA Value of all GroundFloors
         """
-        if self.thermal_zone.use_condition.base_infiltration > 0.5:
+        if self.thermal_zone.use_conditions.base_infiltration > 0.5:
             raise warnings.warn("The base_infiltration is larger than 0.5, "
                                 "which could lead to ideal heaters being too small.")
 

--- a/teaser/logic/buildingobjects/calculation/three_element.py
+++ b/teaser/logic/buildingobjects/calculation/three_element.py
@@ -1282,6 +1282,10 @@ class ThreeElement(object):
         ua_value_gf_temp : float [W/(m2*K)]
             UA Value of all GroundFloors
         """
+        if self.thermal_zone.use_condition.base_infiltration > 0.5:
+            raise warnings.warn("The base_infiltration is larger than 0.5, "
+                                "which could lead to ideal heaters being too small.")
+
         self.heat_load = 0.0
         ua_value_ow_temp = self.ua_value_ow
         self.heat_load_outside_factor = (

--- a/teaser/logic/buildingobjects/calculation/three_element.py
+++ b/teaser/logic/buildingobjects/calculation/three_element.py
@@ -1287,7 +1287,7 @@ class ThreeElement(object):
         self.heat_load_outside_factor = (
             (ua_value_ow_temp + self.ua_value_win)
             + self.thermal_zone.volume
-            * self.thermal_zone.use_conditions.static_infiltration
+            * self.thermal_zone.use_conditions.normative_infiltration
             * 1
             / 3600
             * self.thermal_zone.heat_capac_air

--- a/teaser/logic/buildingobjects/calculation/two_element.py
+++ b/teaser/logic/buildingobjects/calculation/two_element.py
@@ -1171,7 +1171,7 @@ class TwoElement(object):
         ua_value_gf_temp : float [W/(m2*K)]
             UA Value of all GroundFloors
         """
-        if self.thermal_zone.use_condition.base_infiltration > 0.5:
+        if self.thermal_zone.use_conditions.base_infiltration > 0.5:
             raise warnings.warn("The base_infiltration is larger than 0.5, "
                                 "which could lead to ideal heaters being too small.")
 

--- a/teaser/logic/buildingobjects/calculation/two_element.py
+++ b/teaser/logic/buildingobjects/calculation/two_element.py
@@ -1179,7 +1179,7 @@ class TwoElement(object):
         self.heat_load_outside_factor = (
             (ua_value_ow_temp + self.ua_value_win)
             + self.thermal_zone.volume
-            * self.thermal_zone.use_conditions.static_infiltration
+            * self.thermal_zone.use_conditions.normative_infiltration
             * 1
             / 3600
             * self.thermal_zone.heat_capac_air

--- a/teaser/logic/buildingobjects/calculation/two_element.py
+++ b/teaser/logic/buildingobjects/calculation/two_element.py
@@ -1171,6 +1171,10 @@ class TwoElement(object):
         ua_value_gf_temp : float [W/(m2*K)]
             UA Value of all GroundFloors
         """
+        if self.thermal_zone.use_condition.base_infiltration > 0.5:
+            raise warnings.warn("The base_infiltration is larger than 0.5, "
+                                "which could lead to ideal heaters being too small.")
+
         self.heat_load = 0.0
         ua_value_gf_temp = sum(
             ground.ua_value for ground in self.thermal_zone.ground_floors

--- a/teaser/logic/buildingobjects/calculation/two_element.py
+++ b/teaser/logic/buildingobjects/calculation/two_element.py
@@ -1179,7 +1179,7 @@ class TwoElement(object):
         self.heat_load_outside_factor = (
             (ua_value_ow_temp + self.ua_value_win)
             + self.thermal_zone.volume
-            * self.thermal_zone.use_conditions.infiltration_rate
+            * self.thermal_zone.use_conditions.static_infiltration
             * 1
             / 3600
             * self.thermal_zone.heat_capac_air

--- a/teaser/logic/buildingobjects/thermalzone.py
+++ b/teaser/logic/buildingobjects/thermalzone.py
@@ -89,7 +89,6 @@ class ThermalZone(object):
         self.name = None
         self._area = None
         self._volume = None
-        self._infiltration_rate = 0.4
         self._outer_walls = []
         self._doors = []
         self._rooftops = []
@@ -644,18 +643,6 @@ class ThermalZone(object):
                 self._volume = value
         else:
             self._volume = value
-
-    @property
-    def infiltration_rate(self):
-        warnings.warn(
-            "Deprecated for ThermalZone, moved to UseConditions",
-            DeprecationWarning)
-
-    @infiltration_rate.setter
-    def infiltration_rate(self, value):
-        warnings.warn(
-            "Deprecated for ThermalZone, moved to UseConditions",
-            DeprecationWarning)
 
     @property
     def t_inside(self):

--- a/teaser/logic/buildingobjects/useconditions.py
+++ b/teaser/logic/buildingobjects/useconditions.py
@@ -826,3 +826,22 @@ class UseConditions(object):
             )
         self._use_maintained_illuminance = False
         self._lighting_power = value
+
+    @property
+    def infiltration_rate(self):
+        warnings.warn(
+            "'infiltration_rate' is deprecated and will be removed in a future release. "
+            "Use 'base_infiltration' instead.",
+            DeprecationWarning,
+            stacklevel=2)
+        return self.base_infiltration
+
+    @infiltration_rate.setter
+    def infiltration_rate(self, value):
+        self.base_infiltration = value
+        warnings.warn(
+            "'infiltration_rate' is deprecated and will be removed in a future release. "
+            "Use 'base_infiltration' instead.",
+            DeprecationWarning,
+            stacklevel=2)
+

--- a/teaser/logic/buildingobjects/useconditions.py
+++ b/teaser/logic/buildingobjects/useconditions.py
@@ -176,7 +176,7 @@ class UseConditions(object):
         false = natural infiltration + ventilation due to a AHU
         + window infiltration calculated by window opening model
         AixLib: Used on Zone level for ventilation.
-    static_infiltration: float [1/h]
+    normative_infiltration: float [1/h]
         Infiltration rate for static heat load calculation.
         Default is 0.5 based on the DIN EN 12831-1:2017 minimal air exchange rate reference value.
     base_infiltration : float [1/h]
@@ -267,7 +267,7 @@ class UseConditions(object):
         self.lighting_efficiency_lumen = 100  # lighting efficiency in lm/W_el
 
         self.use_constant_infiltration = False
-        self.static_infiltration = 0.5
+        self.normative_infiltration = 0.5
         self.base_infiltration = 0.2
         self.max_user_infiltration = 1.0
         self.max_overheating_infiltration = [3.0, 2.0]

--- a/teaser/logic/buildingobjects/useconditions.py
+++ b/teaser/logic/buildingobjects/useconditions.py
@@ -176,6 +176,9 @@ class UseConditions(object):
         false = natural infiltration + ventilation due to a AHU
         + window infiltration calculated by window opening model
         AixLib: Used on Zone level for ventilation.
+    static_infiltration: float [1/h]
+        Infiltration rate for static heat load calculation.
+        Default is 0.5 based on the DIN EN 12831-1:2017 minimal air exchange rate reference value.
     base_infiltration : float [1/h]
         base value for the natural infiltration without window openings
         AixLib: Used on Zone level for ventilation.
@@ -264,6 +267,7 @@ class UseConditions(object):
         self.lighting_efficiency_lumen = 100  # lighting efficiency in lm/W_el
 
         self.use_constant_infiltration = False
+        self.static_infiltration = 0.5
         self.base_infiltration = 0.2
         self.max_user_infiltration = 1.0
         self.max_overheating_infiltration = [3.0, 2.0]

--- a/teaser/logic/buildingobjects/useconditions.py
+++ b/teaser/logic/buildingobjects/useconditions.py
@@ -264,7 +264,7 @@ class UseConditions(object):
         self.lighting_efficiency_lumen = 100  # lighting efficiency in lm/W_el
 
         self.use_constant_infiltration = False
-        self.infiltration_rate = 0.2
+        self.base_infiltration = 0.2
         self.max_user_infiltration = 1.0
         self.max_overheating_infiltration = [3.0, 2.0]
         self.max_summer_infiltration = [1.0, 273.15 + 10, 273.15 + 17]

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -730,6 +730,10 @@ class Project(object):
         internal_id=None,
         examples=None,
         path=None,
+        THydSup_nominal=None,
+        TOda_nominal=262.65,
+        QBuiOld_flow_design=None,
+        THydSupOld_design=None,
         report=False
     ):
         """Exports buildings for BESMod simulation
@@ -746,7 +750,11 @@ class Project(object):
             all buildings will be exported
         examples: [string]
             List of BESMod.Examples to include buildings in and export them.
-            Supported Examples are: "TEASERHeatLoadCalculation", "ModelicaConferencePaper".
+            Supported Examples are: "TEASERHeatLoadCalculation", "HeatPumpMonoenergetic" and "GasBoilerBuildingOnly".
+        THydSup_nominal: float, dict
+            Nominal hydraulic supply temperature in kelvin.
+        partial_retrofit_args: dict
+            Arguments to specify a partial retrofit model in BESMod. Default is
         path : string
             if the Files should not be stored in default output path of TEASER,
             an alternative path can be specified as a full path
@@ -764,13 +772,17 @@ class Project(object):
 
         if internal_id is None:
             besmod_output.export_besmod(
-                buildings=self.buildings, prj=self, path=path, examples=examples
+                buildings=self.buildings, prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
+                        TOda_nominal=TOda_nominal, QBuiOld_flow_design=QBuiOld_flow_design,
+                        THydSupOld_design=THydSupOld_design
             )
         else:
             for bldg in self.buildings:
                 if bldg.internal_id == internal_id:
                     besmod_output.export_besmod(
-                        buildings=[bldg], prj=self, path=path, examples=examples
+                        buildings=[bldg], prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
+                        TOda_nominal=TOda_nominal, QBuiOld_flow_design=QBuiOld_flow_design,
+                        THydSupOld_design=THydSupOld_design
                     )
 
         if report: # ToDo fwu-hst: Same as AixLib. Maybe create helper function

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -888,6 +888,41 @@ class Project(object):
         self._merge_windows_calc = False
         self._used_library_calc = "AixLib"
 
+    def set_location_parameters(self,
+                     t_outside=262.65,
+                     t_ground=286.15,
+                     weather_file_path=None,
+                     calc_all_buildings=True):
+        """ Set location specific parameters
+
+        Temperatures are used for static heat load calculation
+        and parameters are used in the BESMod export.
+        Default is Mannheim.
+
+        Parameters
+        ----------
+        t_outside: float [K]
+            Normative outdoor temperature for static heat load calculation.
+            The input of t_inside is ALWAYS in Kelvin
+        t_ground: float [K]
+            Temperature directly at the outer side of ground floors for static
+            heat load calculation.
+            The input of t_ground is ALWAYS in Kelvin
+        weather_file_path : str
+            Absolute path to weather file used for Modelica simulation. Default
+            weather file can be find in inputdata/weatherdata.
+        calc_all_buildings: boolean
+            If True, calculates all buildings new.
+            Here imported for changing static heat load.
+        """
+        self.weather_file_path = weather_file_path
+        for bldg in self.buildings:
+            for tz in bldg.thermal_zones:
+                tz.t_outside = t_outside
+                tz.t_ground = t_ground
+        if calc_all_buildings:
+            self.calc_all_buildings()
+
     @staticmethod
     def process_export_vars(export_vars):
         """Process export vars to fit __Dymola_selections syntax."""

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -819,16 +819,14 @@ class Project(object):
         if internal_id is None:
             besmod_output.export_besmod(
                 buildings=self.buildings, prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
-                        TOda_nominal=TOda_nominal, QBuiOld_flow_design=QBuiOld_flow_design,
-                        THydSupOld_design=THydSupOld_design
+                QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design
             )
         else:
             for bldg in self.buildings:
                 if bldg.internal_id == internal_id:
                     besmod_output.export_besmod(
                         buildings=[bldg], prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
-                        TOda_nominal=TOda_nominal, QBuiOld_flow_design=QBuiOld_flow_design,
-                        THydSupOld_design=THydSupOld_design
+                        QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design
                     )
 
         if report: # ToDo fwu-hst: Same as AixLib. Maybe create helper function

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -768,6 +768,7 @@ class Project(object):
         examples=None,
         path=None,
         THydSup_nominal=None,
+        TSetZone_nominal=293.15,
         QBuiOld_flow_design=None,
         THydSupOld_design=None,
         custom_examples=None,
@@ -787,10 +788,21 @@ class Project(object):
             setter of a specific building which will be exported, if None then
             all buildings will be exported
         examples: [string]
-            List of BESMod.Examples to include buildings in and export them.
+            Names of BESMod examples to export alongside the building models.
             Supported Examples are: "TEASERHeatLoadCalculation", "HeatPumpMonoenergetic" and "GasBoilerBuildingOnly".
-        THydSup_nominal: float, dict
-            Nominal hydraulic supply temperature in kelvin.
+        THydSup_nominal : float or dict, optional
+            Nominal supply temperature(s) for the hydraulic system. Required for
+            certain examples (e.g., HeatPumpMonoenergetic, GasBoilerBuildingOnly).
+            See docstring of teaser.data.output.besmod_output.convert_input() for further information.
+        TSetZone_nominal : float or dict, optional
+            Nominal set temperature(s) for the thermal zones.
+            See docstring of teaser.data.output.besmod_output.convert_input() for further information.
+        QBuiOld_flow_design : dict, optional
+            For partially retrofitted systems specify the old nominal heat flow
+            of the Buildings in a dictionary with the building names as keys.
+            By default, only the radiator transfer system is not retrofitted in BESMod.
+        THydSupOld_design : float or dict, optional
+            Design supply temperatures for old not retrofitted hydraulic systems.
         custom_examples: dict, optional
             Specify custom examples with a dictionary containing the example name as the key and
             the path to the corresponding custom mako template as the value.
@@ -815,7 +827,8 @@ class Project(object):
         if internal_id is None:
             besmod_output.export_besmod(
                 buildings=self.buildings, prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
-                QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design,
+                TSetZone_nominal=TSetZone_nominal, QBuiOld_flow_design=QBuiOld_flow_design,
+                THydSupOld_design=THydSupOld_design,
                 custom_examples=custom_examples, custom_script=custom_script
             )
         else:
@@ -823,7 +836,8 @@ class Project(object):
                 if bldg.internal_id == internal_id:
                     besmod_output.export_besmod(
                         buildings=[bldg], prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
-                        QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design,
+                        TSetZone_nominal=TSetZone_nominal, QBuiOld_flow_design=QBuiOld_flow_design,
+                        THydSupOld_design=THydSupOld_design,
                         custom_examples=custom_examples, custom_script=custom_script
                     )
 

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -768,7 +768,6 @@ class Project(object):
         examples=None,
         path=None,
         THydSup_nominal=None,
-        TSetZone_nominal=293.15,
         QBuiOld_flow_design=None,
         THydSupOld_design=None,
         custom_examples=None,
@@ -793,9 +792,6 @@ class Project(object):
         THydSup_nominal : float or dict, optional
             Nominal supply temperature(s) for the hydraulic system. Required for
             certain examples (e.g., HeatPumpMonoenergetic, GasBoilerBuildingOnly).
-            See docstring of teaser.data.output.besmod_output.convert_input() for further information.
-        TSetZone_nominal : float or dict, optional
-            Nominal set temperature(s) for the thermal zones.
             See docstring of teaser.data.output.besmod_output.convert_input() for further information.
         QBuiOld_flow_design : dict, optional
             For partially retrofitted systems specify the old nominal heat flow
@@ -827,8 +823,7 @@ class Project(object):
         if internal_id is None:
             besmod_output.export_besmod(
                 buildings=self.buildings, prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
-                TSetZone_nominal=TSetZone_nominal, QBuiOld_flow_design=QBuiOld_flow_design,
-                THydSupOld_design=THydSupOld_design,
+                QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design,
                 custom_examples=custom_examples, custom_script=custom_script
             )
         else:
@@ -836,8 +831,7 @@ class Project(object):
                 if bldg.internal_id == internal_id:
                     besmod_output.export_besmod(
                         buildings=[bldg], prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
-                        TSetZone_nominal=TSetZone_nominal, QBuiOld_flow_design=QBuiOld_flow_design,
-                        THydSupOld_design=THydSupOld_design,
+                        QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design,
                         custom_examples=custom_examples, custom_script=custom_script
                     )
 

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -777,7 +777,6 @@ class Project(object):
         examples=None,
         path=None,
         THydSup_nominal=None,
-        TOda_nominal=262.65,
         QBuiOld_flow_design=None,
         THydSupOld_design=None,
         report=False

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -955,8 +955,8 @@ class Project(object):
         """ Set location specific parameters
 
         Temperatures are used for static heat load calculation
-        and parameters are used in the BESMod export.
-        Default is Mannheim.
+        and as parameters in the exports.
+        Default location is Mannheim.
 
         Parameters
         ----------
@@ -971,8 +971,8 @@ class Project(object):
             Absolute path to weather file used for Modelica simulation. Default
             weather file can be find in inputdata/weatherdata.
         calc_all_buildings: boolean
-            If True, calculates all buildings new.
-            Here imported for changing static heat load.
+            If True, calculates all buildings new. Default is True.
+            Here important for new calculation of static heat load.
         """
         self.weather_file_path = weather_file_path
         for bldg in self.buildings:

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -3,6 +3,7 @@
 import warnings
 import os
 import re
+from typing import Optional, Union, List, Dict
 import teaser.logic.utilities as utilities
 import teaser.data.utilities as datahandling
 import teaser.data.input.teaserjson_input as tjson_in
@@ -763,17 +764,17 @@ class Project(object):
         return path
 
     def export_besmod(
-        self,
-        internal_id=None,
-        examples=None,
-        path=None,
-        THydSup_nominal=None,
-        QBuiOld_flow_design=None,
-        THydSupOld_design=None,
-        custom_examples=None,
-        custom_script=None,
-        report=False
-    ):
+            self,
+            internal_id: Optional[float] = None,
+            examples: Optional[List[str]] = None,
+            path: Optional[str] = None,
+            THydSup_nominal: Optional[Union[float, Dict[str, float]]] = None,
+            QBuiOld_flow_design: Optional[Dict[str, float]] = None,
+            THydSupOld_design: Optional[Union[float, Dict[str, float]]] = None,
+            custom_examples: Optional[Dict[str, str]] = None,
+            custom_script: Optional[Dict[str, str]] = None,
+            report: bool = False
+    ) -> str:
         """Exports buildings for BESMod simulation
 
         Exports one (if internal_id is not None) or all buildings as
@@ -783,34 +784,36 @@ class Project(object):
         Parameters
         ----------
 
-        internal_id : float
-            setter of a specific building which will be exported, if None then
-            all buildings will be exported
-        examples: [string]
+        internal_id : Optional[float]
+            Specifies a specific building to export by its internal ID. If None, all buildings are exported.
+        examples : Optional[List[str]]
             Names of BESMod examples to export alongside the building models.
-            Supported Examples are: "TEASERHeatLoadCalculation", "HeatPumpMonoenergetic" and "GasBoilerBuildingOnly".
-        THydSup_nominal : float or dict, optional
+            Supported Examples: "TEASERHeatLoadCalculation", "HeatPumpMonoenergetic", and "GasBoilerBuildingOnly".
+        path : Optional[str]
+            Alternative output path for storing the exported files. If None, the default TEASER output path is used.
+        THydSup_nominal : Optional[Union[float, Dict[str, float]]]
             Nominal supply temperature(s) for the hydraulic system. Required for
             certain examples (e.g., HeatPumpMonoenergetic, GasBoilerBuildingOnly).
             See docstring of teaser.data.output.besmod_output.convert_input() for further information.
-        QBuiOld_flow_design : dict, optional
+        QBuiOld_flow_design : Optional[Dict[str, float]
             For partially retrofitted systems specify the old nominal heat flow
             of the Buildings in a dictionary with the building names as keys.
             By default, only the radiator transfer system is not retrofitted in BESMod.
-        THydSupOld_design : float or dict, optional
-            Design supply temperatures for old not retrofitted hydraulic systems.
-        custom_examples: dict, optional
+        THydSupOld_design : Optional[Union[float, Dict[str, float]]]
+            Design supply temperatures for old, non-retrofitted hydraulic systems.
+        custom_examples: Optional[Dict[str, str]]
             Specify custom examples with a dictionary containing the example name as the key and
             the path to the corresponding custom mako template as the value.
-        custom_script: dict, optional
+        custom_script: Optional[Dict[str, str]]
             Specify custom .mos scripts for the existing and custom examples with a dictionary
             containing the example name as the key and the path to the corresponding custom mako template as the value.
-        path : string
-            if the Files should not be stored in default output path of TEASER,
-            an alternative path can be specified as a full path
-        report: boolean
-            if True a model report in form of a html and csv file will be
-            created for the exported project.
+        report : bool
+            If True, generates a model report in HTML and CSV format for the exported project. Default is False.
+
+        Returns
+        -------
+        str
+            The path where the exported files are stored.
         """
 
         if path is None:
@@ -966,7 +969,7 @@ class Project(object):
             weather file can be find in inputdata/weatherdata.
         calc_all_buildings: boolean
             If True, calculates all buildings new. Default is True.
-            Here important for new calculation of static heat load.
+            Important for new calculation of static heat load.
         """
         self.weather_file_path = weather_file_path
         for bldg in self.buildings:

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -759,16 +759,7 @@ class Project(object):
                     )
 
         if report:
-            try:
-                from teaser.data.output.reports import model_report
-            except ImportError:
-                raise ImportError(
-                    "To create the model report, you have to install TEASER "
-                    "using the option report: pip install teaser[report] or install "
-                    "plotly manually."
-                )
-            report_path = os.path.join(path, "Resources", "ModelReport")
-            model_report.create_model_report(prj=self, path=report_path)
+            self._write_report(path)
         return path
 
     def export_besmod(
@@ -836,18 +827,21 @@ class Project(object):
                         custom_examples=custom_examples, custom_script=custom_script
                     )
 
-        if report: # ToDo fwu-hst: Same as AixLib. Maybe create helper function
-            try:
-                from teaser.data.output.reports import model_report
-            except ImportError:
-                raise ImportError(
-                    "To create the model report, you have to install TEASER "
-                    "using the option report: pip install teaser[report] or install "
-                    "plotly manually."
-                )
-            report_path = os.path.join(path, "Resources", "ModelReport")
-            model_report.create_model_report(prj=self, path=report_path)
+        if report:
+            self._write_report(path)
         return path
+
+    def _write_report(self, path):
+        try:
+            from teaser.data.output.reports import model_report
+        except ImportError:
+            raise ImportError(
+                "To create the model report, you have to install TEASER "
+                "using the option report: pip install teaser[report] or install "
+                "plotly manually."
+            )
+        report_path = os.path.join(path, "Resources", "ModelReport")
+        model_report.create_model_report(prj=self, path=report_path)
 
     def export_ibpsa(self, library="AixLib", internal_id=None, path=None):
         """Exports values to a record file for Modelica simulation

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -779,6 +779,8 @@ class Project(object):
         THydSup_nominal=None,
         QBuiOld_flow_design=None,
         THydSupOld_design=None,
+        custom_examples=None,
+        custom_script=None,
         report=False
     ):
         """Exports buildings for BESMod simulation
@@ -798,8 +800,12 @@ class Project(object):
             Supported Examples are: "TEASERHeatLoadCalculation", "HeatPumpMonoenergetic" and "GasBoilerBuildingOnly".
         THydSup_nominal: float, dict
             Nominal hydraulic supply temperature in kelvin.
-        partial_retrofit_args: dict
-            Arguments to specify a partial retrofit model in BESMod. Default is
+        custom_examples: dict, optional
+            Specify custom examples with a dictionary containing the example name as the key and
+            the path to the corresponding custom mako template as the value.
+        custom_script: dict, optional
+            Specify custom .mos scripts for the existing and custom examples with a dictionary
+            containing the example name as the key and the path to the corresponding custom mako template as the value.
         path : string
             if the Files should not be stored in default output path of TEASER,
             an alternative path can be specified as a full path
@@ -818,14 +824,16 @@ class Project(object):
         if internal_id is None:
             besmod_output.export_besmod(
                 buildings=self.buildings, prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
-                QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design
+                QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design,
+                custom_examples=custom_examples, custom_script=custom_script
             )
         else:
             for bldg in self.buildings:
                 if bldg.internal_id == internal_id:
                     besmod_output.export_besmod(
                         buildings=[bldg], prj=self, path=path, examples=examples, THydSup_nominal=THydSup_nominal,
-                        QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design
+                        QBuiOld_flow_design=QBuiOld_flow_design, THydSupOld_design=THydSupOld_design,
+                        custom_examples=custom_examples, custom_script=custom_script
                     )
 
         if report: # ToDo fwu-hst: Same as AixLib. Maybe create helper function

--- a/teaser/project.py
+++ b/teaser/project.py
@@ -769,7 +769,7 @@ class Project(object):
             examples: Optional[List[str]] = None,
             path: Optional[str] = None,
             THydSup_nominal: Optional[Union[float, Dict[str, float]]] = None,
-            QBuiOld_flow_design: Optional[Dict[str, float]] = None,
+            QBuiOld_flow_design: Optional[Dict[str, Dict[str, float]]] = None,
             THydSupOld_design: Optional[Union[float, Dict[str, float]]] = None,
             custom_examples: Optional[Dict[str, str]] = None,
             custom_script: Optional[Dict[str, str]] = None,
@@ -795,9 +795,10 @@ class Project(object):
             Nominal supply temperature(s) for the hydraulic system. Required for
             certain examples (e.g., HeatPumpMonoenergetic, GasBoilerBuildingOnly).
             See docstring of teaser.data.output.besmod_output.convert_input() for further information.
-        QBuiOld_flow_design : Optional[Dict[str, float]
+        QBuiOld_flow_design : Optional[Dict[str, Dict[str, float]]]
             For partially retrofitted systems specify the old nominal heat flow
-            of the Buildings in a dictionary with the building names as keys.
+            of all zones in the Buildings in a nested dictionary with
+            the building names and in a level below the zone names as keys.
             By default, only the radiator transfer system is not retrofitted in BESMod.
         THydSupOld_design : Optional[Union[float, Dict[str, float]]]
             Design supply temperatures for old, non-retrofitted hydraulic systems.

--- a/tests/helptest.py
+++ b/tests/helptest.py
@@ -32,7 +32,6 @@ def building_test2(prj):
     tz.name = "Living Room"
     tz.area = 140.0
     tz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors
-    tz.infiltration_rate = 0.5
 
     tz.use_conditions = UseConditions(tz)
     tz.use_conditions.usage = "Living"

--- a/tests/test_besmod_output.py
+++ b/tests/test_besmod_output.py
@@ -98,7 +98,7 @@ class Test_besmod_output(unittest.TestCase):
             }
             for bldg in prj.buildings
         }
-        custom_template_path = utilities.get_full_path(r"examples\examplefiles\custom_besmod_templates")
+        custom_template_path = utilities.get_full_path("examples/examplefiles/custom_besmod_templates")
         custom_example_template = {"ModelicaConferencePaper": os.path.join(custom_template_path, "custom_template.txt")}
         custom_script = {"HeatPumpMonoenergetic": os.path.join(custom_template_path, "custom_script_hp_mono.txt"),
                          "ModelicaConferencePaper": os.path.join(custom_template_path, "custom_script.txt")}

--- a/tests/test_besmod_output.py
+++ b/tests/test_besmod_output.py
@@ -1,0 +1,259 @@
+import os
+import unittest
+from teaser.logic import utilities
+from teaser.project import Project
+from teaser.data.output.besmod_output import _convert_heating_profile
+
+
+class Test_besmod_output(unittest.TestCase):
+
+    def test_export_besmod(self):
+        """test of export_besmod, no calculation verification"""
+
+        prj = Project()
+
+        prj.add_residential(
+            construction_data='iwu_heavy',
+            geometry_data='iwu_single_family_dwelling',
+            name="ResidentialBuilding",
+            year_of_construction=1988,
+            number_of_floors=2,
+            height_of_floors=3.2,
+            net_leased_area=200.0)
+
+        prj.add_non_residential(
+            construction_data='iwu_heavy',
+            geometry_data='bmvbs_institute',
+            name="InstituteBuilding",
+            year_of_construction=1952,
+            number_of_floors=5,
+            height_of_floors=4.0,
+            net_leased_area=3400.0)
+
+        prj.number_of_elements_calc = 1
+        prj.used_library_calc = "IBPSA"
+        with self.assertRaises(AttributeError):
+            prj.export_besmod()
+        prj.used_library_calc = "AixLib"
+        with self.assertRaises(NotImplementedError):
+            prj.export_besmod()
+        prj.number_of_elements_calc = 4
+        prj.calc_all_buildings()
+        prj.export_besmod()
+        with self.assertRaises(ValueError):
+            prj.export_besmod(examples="wrong_example")
+        examples = ["TEASERHeatLoadCalculation",
+                    "HeatPumpMonoenergetic",
+                    "GasBoilerBuildingOnly"]
+        with self.assertRaises(ValueError):
+            prj.export_besmod(examples=examples)
+
+        prj.export_besmod(examples=examples,
+                          THydSup_nominal=55 + 273.15)
+
+        t_hyd_sup_nominal = {"ResidentialBuilding": 328.15,
+                             "WrongBuilding": {"Office": 343.15,
+                                               "Floor": 343.15,
+                                               "Storage": 343.15,
+                                               "Meeting": 343.15,
+                                               "Restroom": 343.15,
+                                               "ICT": 343.15,
+                                               "Laboratory": 328.15}}
+        with self.assertRaises(KeyError):
+            prj.export_besmod(examples=examples,
+                              THydSup_nominal=t_hyd_sup_nominal)
+
+        t_hyd_sup_nominal = {"ResidentialBuilding": 328.15,
+                             "InstituteBuilding": {"WrongZone": 343.15,
+                                                   "Floor": 343.15,
+                                                   "Storage": 343.15,
+                                                   "Meeting": 343.15,
+                                                   "Restroom": 343.15,
+                                                   "ICT": 343.15,
+                                                   "Laboratory": 328.15}}
+        with self.assertRaises(KeyError):
+            prj.export_besmod(examples=examples,
+                              THydSup_nominal=t_hyd_sup_nominal)
+
+        t_hyd_sup_nominal = {"ResidentialBuilding": 328.15,
+                             "InstituteBuilding": "WrongValue"}
+        with self.assertRaises(ValueError):
+            prj.export_besmod(examples=examples,
+                              THydSup_nominal=t_hyd_sup_nominal)
+
+        t_hyd_sup_nominal = {"ResidentialBuilding": 328.15,
+                             "InstituteBuilding": {"Office": 343.15,
+                                                   "Floor": 343.15,
+                                                   "Storage": 343.15,
+                                                   "Meeting": 343.15,
+                                                   "Restroom": 343.15,
+                                                   "ICT": 343.15,
+                                                   "Laboratory": 328.15}}
+        prj.export_besmod(examples=examples,
+                          THydSup_nominal=t_hyd_sup_nominal)
+
+        q_bui_old_flow_design = {
+            bldg.name: {
+                tz.name: tz.model_attr.heat_load for tz in bldg.thermal_zones
+            }
+            for bldg in prj.buildings
+        }
+        custom_template_path = utilities.get_full_path(r"examples\examplefiles\custom_besmod_templates")
+        custom_example_template = {"ModelicaConferencePaper": os.path.join(custom_template_path, "custom_template.txt")}
+        custom_script = {"HeatPumpMonoenergetic": os.path.join(custom_template_path, "custom_script_hp_mono.txt"),
+                         "ModelicaConferencePaper": os.path.join(custom_template_path, "custom_script.txt")}
+        t_hyd_sup_nominal_old = {1950: 90 + 273.15,
+                               1980: 70 + 273.15}
+        prj.export_besmod(examples=examples,
+                          THydSup_nominal=t_hyd_sup_nominal,
+                          QBuiOld_flow_design=q_bui_old_flow_design,
+                          THydSupOld_design=t_hyd_sup_nominal_old,
+                          custom_examples=custom_example_template,
+                          custom_script=custom_script)
+
+    def test_convert_heating_profile(self):
+        """Test the conversion of heating profiles for BESMod"""
+        with self.assertRaises(ValueError):
+            _convert_heating_profile([293.15])
+        heating_profile = [290.15,
+                           290.15,
+                           290.15,
+                           290.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           290.15,
+                           290.15,
+                           290.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           290.15,
+                           290.15,
+                           290.15]
+        with self.assertRaises(ValueError):
+            _convert_heating_profile(heating_profile)
+        heating_profile = [293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15]
+        t_set_zone_nominal, start_time, width, amplitude = _convert_heating_profile(heating_profile)
+        self.assertEqual(t_set_zone_nominal, 293.15)
+        self.assertAlmostEqual(start_time, 0)
+        self.assertAlmostEqual(width, 1e-50)
+        self.assertEqual(amplitude, 0)
+        heating_profile = [290.15,
+                           290.15,
+                           290.15,
+                           290.15,
+                           290.15,
+                           290.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15]
+        t_set_zone_nominal, start_time, width, amplitude = _convert_heating_profile(heating_profile)
+        self.assertEqual(t_set_zone_nominal, 293.15)
+        self.assertAlmostEqual(start_time, 0)
+        self.assertAlmostEqual(width, 6 / 24 * 100)
+        self.assertEqual(amplitude, -3)
+        heating_profile = [293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           290.15,
+                           290.15,
+                           290.15,
+                           290.15]
+        t_set_zone_nominal, start_time, width, amplitude = _convert_heating_profile(heating_profile)
+        self.assertEqual(t_set_zone_nominal, 293.15)
+        self.assertAlmostEqual(start_time, 20 * 3600)
+        self.assertAlmostEqual(width, 4 / 24 * 100)
+        self.assertEqual(amplitude, -3)
+        heating_profile = [290.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           293.15,
+                           290.15]
+        t_set_zone_nominal, start_time, width, amplitude = _convert_heating_profile(heating_profile)
+        self.assertEqual(t_set_zone_nominal, 293.15)
+        self.assertAlmostEqual(start_time, 23 * 3600)
+        self.assertAlmostEqual(width, 2 / 24 * 100)
+        self.assertEqual(amplitude, -3)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2405,7 +2405,6 @@ class Test_teaser(object):
         tz.name = "LivingRoom"
         tz.area = 140.0
         tz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors
-        tz.infiltration_rate = 0.5
 
         from teaser.logic.buildingobjects.useconditions import UseConditions
 
@@ -2498,7 +2497,6 @@ class Test_teaser(object):
         tz.name = "LivingRoom"
         tz.area = 140.0
         tz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors
-        tz.infiltration_rate = 0.5
 
         from teaser.logic.buildingobjects.useconditions import UseConditions
 
@@ -2619,7 +2617,6 @@ class Test_teaser(object):
         tz.name = "LivingRoom"
         tz.area = 140.0
         tz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors
-        tz.infiltration_rate = 0.5
 
         from teaser.logic.buildingobjects.useconditions import UseConditions
 
@@ -2755,7 +2752,6 @@ class Test_teaser(object):
         tz.name = "LivingRoom"
         tz.area = 140.0
         tz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors
-        tz.infiltration_rate = 0.5
 
         from teaser.logic.buildingobjects.useconditions import UseConditions
 
@@ -2893,7 +2889,6 @@ class Test_teaser(object):
         tz.name = "LivingRoom"
         tz.area = 140.0
         tz.volume = tz.area * bldg.number_of_floors * bldg.height_of_floors
-        tz.infiltration_rate = 0.5
 
         from teaser.logic.buildingobjects.useconditions import UseConditions
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1173,7 +1173,7 @@ class Test_teaser(object):
         )
 
         assert round(prj.buildings[-1].volume, 1) == 490.0
-        assert round(prj.buildings[-1].sum_heat_load, 4) == 5023.0256
+        assert round(prj.buildings[-1].sum_heat_load, 4) == 6659.6256
 
     # methods in therm_zone
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1191,7 +1191,7 @@ class Test_teaser(object):
         """test of heating_load"""
         prj.set_default()
         helptest.building_test2(prj)
-        prj.buildings[-1].thermal_zones[-1].use_conditions.infiltration_rate = 0.5
+        prj.buildings[-1].thermal_zones[-1].use_conditions.base_infiltration = 0.5
         prj.buildings[-1].thermal_zones[-1].calc_zone_parameters(
             number_of_elements=2, merge_windows=True
         )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -67,3 +67,9 @@ class Test_examples(object):
         from teaser.examples import e8_change_boundary_conditions as e8
 
         prj = e8.example_change_boundary_conditions()
+
+    def test_e11_example_export_besmod(self):
+        """Tests the executability of example 11"""
+        from teaser.examples import e11_export_besmod_models as e11
+
+        prj = e11.example_export_besmod()


### PR DESCRIPTION
Closes #733, #746 and #771.
Needs new BESMod version 0.6.0 RWTH-EBC/BESMod#101 and the used AixLib version is increased to 2.1.1.

Additionally, the `use_conditions` parameter `infitration_rate` is renamed to `base_infiltration`, as it was already named in the documentation and the parameter `static_infiltration` is added which is now used for the static heat load calculation with a value of 0.5.
