### PR TITLE
Update TypeElements_IWU.json

### DIFF
--- a/teaser/data/input/inputdata/TypeElements_IWU.json
+++ b/teaser/data/input/inputdata/TypeElements_IWU.json
@@ -1219,7 +1219,7 @@
             "2": {
                 "thickness": 0.14,
                 "material": {
-                    "name": "wood_fibreboard_iwu_light_200",
+                    "name": "wood_fibreboard_light_200",
                     "material_id": "2b23145c-3a43-11e7-ad60-2cd444b2e704"
                 }
             }


### PR DESCRIPTION
Fixes a wrong material name. Before was `wood_fibreboard_iwu_light_200`, but this material does not exist. The material that exists is `wood_fibreboard_light_200` 

This might have happend due to automatic find->replace (light ->> iwu_light)