### PR TITLE
correct shading_max_irr values

### DIFF
--- a/teaser/logic/buildingobjects/calculation/four_element.py
+++ b/teaser/logic/buildingobjects/calculation/four_element.py
@@ -1490,7 +1490,7 @@ class FourElement(object):
             if not wins:
                 self.weightfactor_win.append(0.0)
                 self.shading_g_total.append(1.0)
-                self.shading_max_irr.append(0.0)
+                self.shading_max_irr.append(9999.0)
                 self.window_areas.append(0.0)
                 self.transparent_areas.append(0.0)
             else:

--- a/teaser/logic/buildingobjects/calculation/one_element.py
+++ b/teaser/logic/buildingobjects/calculation/one_element.py
@@ -939,7 +939,7 @@ class OneElement(object):
             if not wins:
                 self.weightfactor_win.append(0.0)
                 self.shading_g_total.append(1.0)
-                self.shading_max_irr.append(0.0)
+                self.shading_max_irr.append(9999.0)
                 self.window_areas.append(0.0)
                 self.transparent_areas.append(0.0)
             else:

--- a/teaser/logic/buildingobjects/calculation/three_element.py
+++ b/teaser/logic/buildingobjects/calculation/three_element.py
@@ -1239,7 +1239,7 @@ class ThreeElement(object):
             if not wins:
                 self.weightfactor_win.append(0.0)
                 self.shading_g_total.append(1.0)
-                self.shading_max_irr.append(0.0)
+                self.shading_max_irr.append(9999.0)
                 self.window_areas.append(0.0)
                 self.transparent_areas.append(0.0)
             else:

--- a/teaser/logic/buildingobjects/calculation/two_element.py
+++ b/teaser/logic/buildingobjects/calculation/two_element.py
@@ -1127,7 +1127,6 @@ class TwoElement(object):
             if not wins:
                 self.weightfactor_win.append(0.0)
                 self.shading_g_total.append(1.0)
-                self.shading_max_irr.append(0.0)
                 self.window_areas.append(0.0)
                 self.transparent_areas.append(0.0)
                 self.shading_max_irr.append(9999.9)


### PR DESCRIPTION
original changes were not correct. For two_element model a dummy value already existed and was set to 9999.0. I removed the duplicated dummy value and added 9999.0 instead of zero to the other models.