### PR TITLE
update calculations from round() to approx

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1563,7 +1563,7 @@ class Test_teaser(object):
         assert calc_attr.alpha_comb_inner_iw == approx(7.7, abs=0.1)
 
         # outerwall
-        assert calc_attr.ua_value_ow == approx(77.23037843150993, abs=1e-14)
+        assert calc_attr.ua_value_ow == approx(77.23037843150993, abs=1e-13)
         assert calc_attr.area_ow == approx(188.0, abs=0.1)
         assert calc_attr.r_conv_inner_ow == approx(0.0027203482045701846,
                                                    abs=1e-19)
@@ -1960,6 +1960,7 @@ class Test_teaser(object):
 
     def test_calc_weightfactor_three(self):
         """test of calc_weightfactor"""
+
         prj.set_default()
         helptest.building_test2(prj)
         prj.buildings[-1].calc_building_parameter(
@@ -1977,7 +1978,9 @@ class Test_teaser(object):
         calc_attr.weightfactor_ow.sort()
         weightfactors_test_list.sort()
 
-        assert calc_attr.weightfactor_ow == weightfactors_test_list
+        assert calc_attr.weightfactor_ow == approx(weightfactors_test_list,
+                                                   abs=1e-14)
+
         weightfactors_test_list = [
             0.13271234911406493,
             0.0,
@@ -1987,7 +1990,8 @@ class Test_teaser(object):
         ]
         calc_attr.weightfactor_win.sort()
         weightfactors_test_list.sort()
-        assert calc_attr.weightfactor_win == weightfactors_test_list
+        assert calc_attr.weightfactor_win == approx(weightfactors_test_list,
+                                                    abs=1e-14)
         assert calc_attr.weightfactor_ground == 0
 
         prj.buildings[-1].thermal_zones[-1].weightfactor_ow = []
@@ -2009,7 +2013,8 @@ class Test_teaser(object):
         calc_attr.weightfactor_ow.sort()
         weightfactors_test_list.sort()
 
-        assert calc_attr.weightfactor_ow == weightfactors_test_list
+        assert calc_attr.weightfactor_ow == approx(weightfactors_test_list,
+                                                   abs=1e-14)
 
         weightfactors_test_list = [
             0.44444444444444453,
@@ -2020,7 +2025,8 @@ class Test_teaser(object):
         ]
         calc_attr.weightfactor_win.sort()
         weightfactors_test_list.sort()
-        assert calc_attr.weightfactor_win == weightfactors_test_list
+        assert calc_attr.weightfactor_win == approx(weightfactors_test_list,
+                                                    abs=1e-14)
         assert calc_attr.weightfactor_ground == 0
 
     def test_calc_weightfactor_four(self):
@@ -2167,61 +2173,70 @@ class Test_teaser(object):
 
     def test_calc_three_element(self):
         """test of calc_two_element"""
+        from pytest import approx
         prj.set_default()
         helptest.building_test2(prj)
 
         therm_zone = prj.buildings[-1].thermal_zones[-1]
-        therm_zone.calc_zone_parameters(number_of_elements=3, merge_windows=True)
+        therm_zone.calc_zone_parameters(number_of_elements=3,
+                                        merge_windows=True)
 
         zone_attr = therm_zone.model_attr
-        assert round(zone_attr.area_ow, 1) == 188.0
-        assert round(zone_attr.ua_value_ow, 16) == 77.23037843150993
-        assert round(zone_attr.r_conv_inner_ow, 16) == 0.0027203482045702
-        assert round(zone_attr.r_rad_inner_ow, 16) == 0.001063829787234
-        assert round(zone_attr.r_conv_outer_ow, 9) == 0.000265957
-        assert round(zone_attr.alpha_conv_inner_ow, 5) == 1.95532
-        assert round(zone_attr.alpha_rad_inner_ow, 1) == 5.0
-        assert round(zone_attr.r1_ow, 14) == 0.00114890338306
-        assert round(zone_attr.c1_ow, 5) == 2091259.60825
-        assert round(zone_attr.r1_iw, 15) == 0.009719561140816
-        assert round(zone_attr.c1_iw, 5) == 319983.51874
-        assert round(zone_attr.r_rest_ow, 11) == 0.00702003101
-        assert round(zone_attr.area_gf, 1) == 140.0
-        assert round(zone_attr.ua_value_gf, 16) == 58.351477449455686
-        assert round(zone_attr.r_conv_inner_gf, 16) == 0.0042016806722689
-        assert round(zone_attr.r_rad_inner_gf, 16) == 0.0014285714285714
-        assert round(zone_attr.alpha_conv_inner_gf, 5) == 1.7
-        assert round(zone_attr.alpha_rad_inner_gf, 1) == 5.0
-        assert round(zone_attr.r1_gf, 14) == 0.00236046484848
-        assert round(zone_attr.c1_gf, 5) == 1557320.98487
-        assert round(zone_attr.r_rest_gf, 13) == 0.0137109637229
+        assert zone_attr.area_ow == approx(188.0, abs=0.1)
+        assert zone_attr.ua_value_ow == approx(77.23037843150993, abs=1e-13)
+        assert zone_attr.r_conv_inner_ow == approx(0.0027203482045702,
+                                                   abs=1e-14)
+        assert zone_attr.r_rad_inner_ow == approx(0.001063829787234, abs=1e-14)
+        assert zone_attr.r_conv_outer_ow == approx(0.000265957, abs=1e-9)
+        assert zone_attr.alpha_conv_inner_ow == approx(1.95532, abs=0.00001)
+        assert zone_attr.alpha_rad_inner_ow == approx(5.0, abs=0.1)
+        assert zone_attr.r1_ow == approx(0.00114890338306, abs=1e-14)
+        assert zone_attr.c1_ow == approx(2091259.60825, abs=0.00001)
+        assert zone_attr.r1_iw == approx(0.009719561140816, abs=1e-15)
+        assert zone_attr.c1_iw == approx(319983.51874, abs=0.00001)
+        assert zone_attr.r_rest_ow == approx(0.00702003101, abs=1e-11)
+        assert zone_attr.area_gf == approx(140.0, abs=0.1)
+        assert zone_attr.ua_value_gf == approx(58.351477449455686, abs=1e-14)
+        assert zone_attr.r_conv_inner_gf == approx(0.0042016806722689,
+                                                   abs=1e-14)
+        assert zone_attr.r_rad_inner_gf == approx(0.0014285714285714,
+                                                  abs=1e-14)
+        assert zone_attr.alpha_conv_inner_gf == approx(1.7, abs=0.00001)
+        assert zone_attr.alpha_rad_inner_gf == approx(5.0, abs=0.1)
+        assert zone_attr.r1_gf == approx(0.00236046484848, abs=1e-14)
+        assert zone_attr.c1_gf == approx(1557320.98487, abs=0.00001)
+        assert zone_attr.r_rest_gf == approx(0.0137109637229, abs=1e-13)
 
         therm_zone = prj.buildings[-1].thermal_zones[-1]
-        therm_zone.calc_zone_parameters(number_of_elements=3, merge_windows=False)
+        therm_zone.calc_zone_parameters(number_of_elements=3,
+                                        merge_windows=False)
 
         zone_attr = therm_zone.model_attr
-        assert round(zone_attr.area_ow, 1) == 188.0
-        assert round(zone_attr.ua_value_ow, 16) == 77.23037843150993
-        assert round(zone_attr.r_conv_inner_ow, 16) == 0.0027203482045702
-        assert round(zone_attr.r_rad_inner_ow, 16) == 0.001063829787234
-        assert round(zone_attr.r_conv_outer_ow, 9) == 0.000265957
-        assert round(zone_attr.alpha_conv_inner_ow, 5) == 1.95532
-        assert round(zone_attr.alpha_rad_inner_ow, 1) == 5.0
-        assert round(zone_attr.r1_win, 13) == 0.0199004975124
-        assert round(zone_attr.r1_ow, 13) == 0.0017577929723
-        assert round(zone_attr.c1_ow, 5) == 2091259.60825
-        assert round(zone_attr.r1_iw, 15) == 0.009719561140816
-        assert round(zone_attr.c1_iw, 5) == 319983.51874
-        assert round(zone_attr.r_rest_ow, 13) == 0.0102102921341
-        assert round(zone_attr.area_gf, 1) == 140.0
-        assert round(zone_attr.ua_value_gf, 16) == 58.351477449455686
-        assert round(zone_attr.r_conv_inner_gf, 16) == 0.0042016806722689
-        assert round(zone_attr.r_rad_inner_gf, 16) == 0.0014285714285714
-        assert round(zone_attr.alpha_conv_inner_gf, 5) == 1.7
-        assert round(zone_attr.alpha_rad_inner_gf, 1) == 5.0
-        assert round(zone_attr.r1_gf, 14) == 0.00236046484848
-        assert round(zone_attr.c1_gf, 5) == 1557320.98487
-        assert round(zone_attr.r_rest_gf, 13) == 0.0137109637229
+        assert zone_attr.area_ow == approx(188.0, abs=0.1)
+        assert zone_attr.ua_value_ow == approx(77.23037843150993, abs=1e-13)
+        assert zone_attr.r_conv_inner_ow == approx(0.0027203482045702,
+                                                   abs=1e-14)
+        assert zone_attr.r_rad_inner_ow == approx(0.001063829787234, abs=1e-14)
+        assert zone_attr.r_conv_outer_ow == approx(0.000265957, abs=1e-9)
+        assert zone_attr.alpha_conv_inner_ow == approx(1.95532, abs=0.00001)
+        assert zone_attr.alpha_rad_inner_ow == approx(5.0, abs=0.1)
+        assert zone_attr.r1_win == approx(0.0199004975124, abs=1e-13)
+        assert zone_attr.r1_ow == approx(0.0017577929723, abs=1e-13)
+        assert zone_attr.c1_ow == approx(2091259.60825, abs=0.00001)
+        assert zone_attr.r1_iw == approx(0.009719561140816, abs=1e-15)
+        assert zone_attr.c1_iw == approx(319983.51874, abs=0.00001)
+        assert zone_attr.r_rest_ow == approx(0.0102102921341, abs=1e-13)
+        assert zone_attr.area_gf == approx(140.0, abs=0.1)
+        assert zone_attr.ua_value_gf == approx(58.351477449455686, abs=1e-14)
+        assert zone_attr.r_conv_inner_gf == approx(0.0042016806722689,
+                                                   abs=1e-14)
+        assert zone_attr.r_rad_inner_gf == approx(0.0014285714285714,
+                                                  abs=1e-14)
+        assert zone_attr.alpha_conv_inner_gf == approx(1.7, abs=0.00001)
+        assert zone_attr.alpha_rad_inner_gf == approx(5.0, abs=0.1)
+        assert zone_attr.r1_gf == approx(0.00236046484848, abs=1e-14)
+        assert zone_attr.c1_gf == approx(1557320.98487, abs=0.00001)
+        assert zone_attr.r_rest_gf == approx(0.0137109637229, abs=1e-13)
 
     def test_calc_four_element(self):
         """test of calc_two_element"""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -13,7 +13,7 @@ from teaser.data.dataclass import DataClass
 import math
 import os
 import helptest
-import warnings as warnings
+from pytest import approx
 
 prj = Project(False)
 prj.data = DataClass(construction_data=ConstructionData.iwu_heavy)
@@ -1315,34 +1315,42 @@ class Test_teaser(object):
         calc_attr._sum_window_elements()
 
         # outerwall
-        assert round(calc_attr.ua_value_ow, 16) == 135.5818558809656
-        assert round(calc_attr.area_ow, 1) == 328.0
-        assert round(calc_attr.r_conv_inner_ow, 19) == 0.0016512549537648611
-        assert round(calc_attr.r_rad_inner_ow, 18) == 0.000609756097560976
-        assert round(calc_attr.r_comb_inner_ow, 20) == 0.00044531528322052017
-        assert round(calc_attr.r_conv_outer_ow, 20) == 0.00026595744680851064
-        assert round(calc_attr.r_rad_outer_ow, 18) == 0.001063829787234043
-        assert round(calc_attr.r_comb_outer_ow, 20) == 0.0002127659574468085
-        assert round(calc_attr.alpha_conv_inner_ow, 5) == 1.84634
-        assert round(calc_attr.alpha_rad_inner_ow, 5) == 5.0
-        assert round(calc_attr.alpha_comb_inner_ow, 5) == 6.84634
-        assert round(calc_attr.alpha_conv_outer_ow, 1) == 20.0
-        assert round(calc_attr.alpha_rad_outer_ow, 5) == 5.0
-        assert round(calc_attr.alpha_comb_outer_ow, 1) == 25.0
+        assert calc_attr.ua_value_ow == approx(135.5818558809656, abs=1e-14)
+        assert calc_attr.area_ow == approx(328.0, abs=0.1)
+        assert calc_attr.r_conv_inner_ow == approx(0.0016512549537648611,
+                                                   abs=1e-19)
+        assert calc_attr.r_rad_inner_ow == approx(0.000609756097560976,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_inner_ow == approx(0.00044531528322052017,
+                                                   abs=1e-20)
+        assert calc_attr.r_conv_outer_ow == approx(0.00026595744680851064,
+                                                   abs=1e-20)
+        assert calc_attr.r_rad_outer_ow == approx(0.001063829787234043,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_outer_ow == approx(0.0002127659574468085,
+                                                   abs=1e-20)
+        assert calc_attr.alpha_conv_inner_ow == approx(1.84634, abs=0.00001)
+        assert calc_attr.alpha_rad_inner_ow == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_inner_ow == approx(6.84634, abs=0.00001)
+        assert calc_attr.alpha_conv_outer_ow == approx(20.0, abs=0.1)
+        assert calc_attr.alpha_rad_outer_ow == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_outer_ow == approx(25.0, abs=0.1)
 
         # window
-        assert round(calc_attr.ua_value_win, 16) == 32.87895310796074
-        assert round(calc_attr.area_win, 1) == 18.0
-        assert round(calc_attr.r_conv_inner_win, 19) == 0.032679738562091505
-        assert round(calc_attr.r_rad_inner_win, 4) == 0.0111
-        assert round(calc_attr.r_comb_inner_win, 19) == 0.008291873963515755
-        assert round(calc_attr.r_conv_outer_win, 5) == 0.00278
-        assert round(calc_attr.r_rad_outer_win, 4) == 0.0111
-        assert round(calc_attr.r_comb_outer_win, 4) == 0.0022
-        assert round(calc_attr.alpha_conv_inner_win, 1) == 1.7
-        assert round(calc_attr.alpha_comb_outer_win, 1) == 25.0
-        assert round(calc_attr.alpha_conv_outer_win, 1) == 20.0
-        assert round(calc_attr.weighted_g_value, 3) == 0.789
+        assert calc_attr.ua_value_win == approx(32.87895310796074, abs=1e-14)
+        assert calc_attr.area_win == approx(18.0, abs=0.1)
+        assert calc_attr.r_conv_inner_win == approx(0.032679738562091505,
+                                                    abs=1e-19)
+        assert calc_attr.r_rad_inner_win == approx(0.0111, abs=0.0001)
+        assert calc_attr.r_comb_inner_win == approx(0.008291873963515755,
+                                                    abs=1e-19)
+        assert calc_attr.r_conv_outer_win == approx(0.00278, abs=0.00001)
+        assert calc_attr.r_rad_outer_win == approx(0.0111, abs=0.0001)
+        assert calc_attr.r_comb_outer_win == approx(0.0022, abs=0.0001)
+        assert calc_attr.alpha_conv_inner_win == approx(1.7, abs=0.1)
+        assert calc_attr.alpha_comb_outer_win == approx(25.0, abs=0.1)
+        assert calc_attr.alpha_conv_outer_win == approx(20.0, abs=0.1)
+        assert calc_attr.weighted_g_value == approx(0.789, abs=0.001)
 
     def test_calc_chain_matrix_one(self):
         """test of calc_chain_matrix"""
@@ -1412,45 +1420,55 @@ class Test_teaser(object):
         calc_attr._sum_window_elements()
 
         # innerwall
-
-        assert round(calc_attr.ua_value_iw, 16) == 14.286493860845841
-        assert round(calc_attr.area_iw, 1) == 34.0
-        assert round(calc_attr.r_conv_inner_iw, 18) == 0.010893246187363833
-        assert round(calc_attr.r_rad_inner_iw, 19) == 0.0058823529411764705
-        assert round(calc_attr.r_comb_inner_iw, 19) == 0.003819709702062643
-        assert round(calc_attr.alpha_conv_inner_iw, 1) == 2.7
-        assert round(calc_attr.alpha_rad_inner_iw, 1) == 5.0
-        assert round(calc_attr.alpha_comb_inner_iw, 1) == 7.7
+        assert calc_attr.ua_value_iw == approx(14.286493860845841, abs=1e-14)
+        assert calc_attr.area_iw == approx(34.0, abs=0.1)
+        assert calc_attr.r_conv_inner_iw == approx(0.010893246187363833,
+                                                   abs=1e-18)
+        assert calc_attr.r_rad_inner_iw == approx(0.0058823529411764705,
+                                                  abs=1e-19)
+        assert calc_attr.r_comb_inner_iw == approx(0.003819709702062643,
+                                                   abs=1e-19)
+        assert calc_attr.alpha_conv_inner_iw == approx(2.7, abs=0.1)
+        assert calc_attr.alpha_rad_inner_iw == approx(5.0, abs=0.1)
+        assert calc_attr.alpha_comb_inner_iw == approx(7.7, abs=0.1)
 
         # outerwall
-        assert round(calc_attr.ua_value_ow, 16) == 135.5818558809656
-        assert round(calc_attr.area_ow, 1) == 328.0
-        assert round(calc_attr.r_conv_inner_ow, 19) == 0.0016512549537648611
-        assert round(calc_attr.r_rad_inner_ow, 18) == 0.000609756097560976
-        assert round(calc_attr.r_comb_inner_ow, 20) == 0.00044531528322052017
-        assert round(calc_attr.r_conv_outer_ow, 20) == 0.00026595744680851064
-        assert round(calc_attr.r_rad_outer_ow, 18) == 0.001063829787234043
-        assert round(calc_attr.r_comb_outer_ow, 20) == 0.0002127659574468085
-        assert round(calc_attr.alpha_conv_inner_ow, 5) == 1.84634
-        assert round(calc_attr.alpha_rad_inner_ow, 5) == 5.0
-        assert round(calc_attr.alpha_comb_inner_ow, 5) == 6.84634
-        assert round(calc_attr.alpha_conv_outer_ow, 1) == 20.0
-        assert round(calc_attr.alpha_rad_outer_ow, 5) == 5.0
-        assert round(calc_attr.alpha_comb_outer_ow, 1) == 25.0
+        assert calc_attr.ua_value_ow == approx(135.5818558809656, abs=1e-14)
+        assert calc_attr.area_ow == approx(328.0, abs=0.1)
+        assert calc_attr.r_conv_inner_ow == approx(0.0016512549537648611,
+                                                   abs=1e-19)
+        assert calc_attr.r_rad_inner_ow == approx(0.000609756097560976,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_inner_ow == approx(0.00044531528322052017,
+                                                   abs=1e-20)
+        assert calc_attr.r_conv_outer_ow == approx(0.00026595744680851064,
+                                                   abs=1e-20)
+        assert calc_attr.r_rad_outer_ow == approx(0.001063829787234043,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_outer_ow == approx(0.0002127659574468085,
+                                                   abs=1e-20)
+        assert calc_attr.alpha_conv_inner_ow == approx(1.84634, abs=0.00001)
+        assert calc_attr.alpha_rad_inner_ow == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_inner_ow == approx(6.84634, abs=0.00001)
+        assert calc_attr.alpha_conv_outer_ow == approx(20.0, abs=0.1)
+        assert calc_attr.alpha_rad_outer_ow == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_outer_ow == approx(25.0, abs=0.1)
 
         # window
-        assert round(calc_attr.ua_value_win, 16) == 32.87895310796074
-        assert round(calc_attr.area_win, 1) == 18.0
-        assert round(calc_attr.r_conv_inner_win, 19) == 0.032679738562091505
-        assert round(calc_attr.r_rad_inner_win, 4) == 0.0111
-        assert round(calc_attr.r_comb_inner_win, 19) == 0.008291873963515755
-        assert round(calc_attr.r_conv_outer_win, 5) == 0.00278
-        assert round(calc_attr.r_rad_outer_win, 4) == 0.0111
-        assert round(calc_attr.r_comb_outer_win, 4) == 0.0022
-        assert round(calc_attr.alpha_conv_inner_win, 1) == 1.7
-        assert round(calc_attr.alpha_comb_outer_win, 1) == 25.0
-        assert round(calc_attr.alpha_conv_outer_win, 1) == 20.0
-        assert round(calc_attr.weighted_g_value, 3) == 0.789
+        assert calc_attr.ua_value_win == approx(32.87895310796074, abs=1e-14)
+        assert calc_attr.area_win == approx(18.0, abs=0.1)
+        assert calc_attr.r_conv_inner_win == approx(0.032679738562091505,
+                                                    abs=1e-19)
+        assert calc_attr.r_rad_inner_win == approx(0.0111, abs=0.0001)
+        assert calc_attr.r_comb_inner_win == approx(0.008291873963515755,
+                                                    abs=1e-19)
+        assert calc_attr.r_conv_outer_win == approx(0.00278, abs=0.00001)
+        assert calc_attr.r_rad_outer_win == approx(0.0111, abs=0.0001)
+        assert calc_attr.r_comb_outer_win == approx(0.0022, abs=0.0001)
+        assert calc_attr.alpha_conv_inner_win == approx(1.7, abs=0.1)
+        assert calc_attr.alpha_comb_outer_win == approx(25.0, abs=0.1)
+        assert calc_attr.alpha_conv_outer_win == approx(20.0, abs=0.1)
+        assert calc_attr.weighted_g_value == approx(0.789, abs=0.001)
 
     def test_calc_chain_matrix_two(self):
         """test of calc_chain_matrix"""
@@ -1532,55 +1550,68 @@ class Test_teaser(object):
         calc_attr._sum_window_elements()
 
         # innerwall
-
-        assert round(calc_attr.ua_value_iw, 16) == 14.286493860845841
-        assert round(calc_attr.area_iw, 1) == 34.0
-        assert round(calc_attr.r_conv_inner_iw, 18) == 0.010893246187363833
-        assert round(calc_attr.r_rad_inner_iw, 19) == 0.0058823529411764705
-        assert round(calc_attr.r_comb_inner_iw, 19) == 0.003819709702062643
-        assert round(calc_attr.alpha_conv_inner_iw, 1) == 2.7
-        assert round(calc_attr.alpha_rad_inner_iw, 1) == 5.0
-        assert round(calc_attr.alpha_comb_inner_iw, 1) == 7.7
+        assert calc_attr.ua_value_iw == approx(14.286493860845841, abs=1e-14)
+        assert calc_attr.area_iw == approx(34.0, abs=0.1)
+        assert calc_attr.r_conv_inner_iw == approx(0.010893246187363833,
+                                                   abs=1e-18)
+        assert calc_attr.r_rad_inner_iw == approx(0.0058823529411764705,
+                                                  abs=1e-19)
+        assert calc_attr.r_comb_inner_iw == approx(0.003819709702062643,
+                                                   abs=1e-19)
+        assert calc_attr.alpha_conv_inner_iw == approx(2.7, abs=0.1)
+        assert calc_attr.alpha_rad_inner_iw == approx(5.0, abs=0.1)
+        assert calc_attr.alpha_comb_inner_iw == approx(7.7, abs=0.1)
 
         # outerwall
-        assert round(calc_attr.ua_value_ow, 16) == 77.23037843150993
-        assert round(calc_attr.area_ow, 1) == 188.0
-        assert round(calc_attr.r_conv_inner_ow, 19) == 0.0027203482045701846
-        assert round(calc_attr.r_rad_inner_ow, 18) == 0.001063829787234043
-        assert round(calc_attr.r_comb_inner_ow, 20) == 0.0007647598654022638
-        assert round(calc_attr.r_conv_outer_ow, 20) == 0.00026595744680851064
-        assert round(calc_attr.r_rad_outer_ow, 18) == 0.001063829787234043
-        assert round(calc_attr.r_comb_outer_ow, 20) == 0.0002127659574468085
-        assert round(calc_attr.alpha_conv_inner_ow, 5) == 1.95532
-        assert round(calc_attr.alpha_rad_inner_ow, 5) == 5.0
-        assert round(calc_attr.alpha_comb_inner_ow, 5) == 6.95532
-        assert round(calc_attr.alpha_conv_outer_ow, 1) == 20.0
-        assert round(calc_attr.alpha_rad_outer_ow, 5) == 5.0
-        assert round(calc_attr.alpha_comb_outer_ow, 1) == 25.0
+        assert calc_attr.ua_value_ow == approx(77.23037843150993, abs=1e-14)
+        assert calc_attr.area_ow == approx(188.0, abs=0.1)
+        assert calc_attr.r_conv_inner_ow == approx(0.0027203482045701846,
+                                                   abs=1e-19)
+        assert calc_attr.r_rad_inner_ow == approx(0.001063829787234043,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_inner_ow == approx(0.0007647598654022638,
+                                                   abs=1e-20)
+        assert calc_attr.r_conv_outer_ow == approx(0.00026595744680851064,
+                                                   abs=1e-20)
+        assert calc_attr.r_rad_outer_ow == approx(0.001063829787234043,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_outer_ow == approx(0.0002127659574468085,
+                                                   abs=1e-20)
+        assert calc_attr.alpha_conv_inner_ow == approx(1.95532, abs=0.00001)
+        assert calc_attr.alpha_rad_inner_ow == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_inner_ow == approx(6.95532, abs=0.00001)
+        assert calc_attr.alpha_conv_outer_ow == approx(20.0, abs=0.1)
+        assert calc_attr.alpha_rad_outer_ow == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_outer_ow == approx(25.0, abs=0.1)
 
         # groundfloor
-        assert round(calc_attr.ua_value_gf, 16) == 58.351477449455686
-        assert round(calc_attr.area_gf, 1) == 140.0
-        assert round(calc_attr.r_conv_inner_gf, 19) == 0.004201680672268907
-        assert round(calc_attr.r_rad_inner_gf, 18) == 0.001428571428571429
-        assert round(calc_attr.r_comb_inner_gf, 20) == 0.0010660980810234541
-        assert round(calc_attr.alpha_conv_inner_gf, 5) == 1.7
-        assert round(calc_attr.alpha_rad_inner_gf, 5) == 5.0
-        assert round(calc_attr.alpha_comb_inner_gf, 5) == 6.7
+        assert calc_attr.ua_value_gf == approx(58.351477449455686, abs=1e-14)
+        assert calc_attr.area_gf == approx(140.0, abs=0.1)
+        assert calc_attr.r_conv_inner_gf == approx(0.004201680672268907,
+                                                   abs=1e-19)
+        assert calc_attr.r_rad_inner_gf == approx(0.001428571428571429,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_inner_gf == approx(0.0010660980810234541,
+                                                   abs=1e-20)
+        assert calc_attr.alpha_conv_inner_gf == approx(1.7, abs=0.00001)
+        assert calc_attr.alpha_rad_inner_gf == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_inner_gf == approx(6.7, abs=0.00001)
 
         # window
-        assert round(calc_attr.ua_value_win, 16) == 32.87895310796074
-        assert round(calc_attr.area_win, 1) == 18.0
-        assert round(calc_attr.r_conv_inner_win, 19) == 0.032679738562091505
-        assert round(calc_attr.r_rad_inner_win, 4) == 0.0111
-        assert round(calc_attr.r_comb_inner_win, 19) == 0.008291873963515755
-        assert round(calc_attr.r_conv_outer_win, 5) == 0.00278
-        assert round(calc_attr.r_rad_outer_win, 4) == 0.0111
-        assert round(calc_attr.r_comb_outer_win, 4) == 0.0022
-        assert round(calc_attr.alpha_conv_inner_win, 1) == 1.7
-        assert round(calc_attr.alpha_comb_outer_win, 1) == 25.0
-        assert round(calc_attr.alpha_conv_outer_win, 1) == 20.0
-        assert round(calc_attr.weighted_g_value, 3) == 0.789
+        assert calc_attr.ua_value_win == approx(32.87895310796074, abs=1e-14)
+        assert calc_attr.area_win == approx(18.0, abs=0.1)
+        assert calc_attr.r_conv_inner_win == approx(0.032679738562091505,
+                                                    abs=1e-19)
+        assert calc_attr.r_rad_inner_win == approx(0.0111, abs=0.0001)
+        assert calc_attr.r_comb_inner_win == approx(0.008291873963515755,
+                                                    abs=1e-19)
+        assert calc_attr.r_conv_outer_win == approx(0.00278, abs=0.00001)
+        assert calc_attr.r_rad_outer_win == approx(0.0111, abs=0.0001)
+        assert calc_attr.r_comb_outer_win == approx(0.0022, abs=0.0001)
+        assert calc_attr.alpha_conv_inner_win == approx(1.7, abs=0.1)
+        assert calc_attr.alpha_comb_outer_win == approx(25.0, abs=0.1)
+        assert calc_attr.alpha_conv_outer_win == approx(20.0, abs=0.1)
+        assert calc_attr.weighted_g_value == approx(0.789, abs=0.001)
 
     def test_calc_chain_matrix_three(self):
         """test of calc_chain_matrix"""
@@ -1658,71 +1689,90 @@ class Test_teaser(object):
         calc_attr._sum_window_elements()
 
         # innerwall
-
-        assert round(calc_attr.ua_value_iw, 16) == 14.286493860845841
-        assert round(calc_attr.area_iw, 1) == 34.0
-        assert round(calc_attr.r_conv_inner_iw, 18) == 0.010893246187363833
-        assert round(calc_attr.r_rad_inner_iw, 19) == 0.0058823529411764705
-        assert round(calc_attr.r_comb_inner_iw, 19) == 0.003819709702062643
-        assert round(calc_attr.alpha_conv_inner_iw, 1) == 2.7
-        assert round(calc_attr.alpha_rad_inner_iw, 1) == 5.0
-        assert round(calc_attr.alpha_comb_inner_iw, 1) == 7.7
+        assert calc_attr.ua_value_iw == approx(14.286493860845841, abs=1e-14)
+        assert calc_attr.area_iw == approx(34.0, abs=0.1)
+        assert calc_attr.r_conv_inner_iw == approx(0.010893246187363833,
+                                                   abs=1e-18)
+        assert calc_attr.r_rad_inner_iw == approx(0.0058823529411764705,
+                                                  abs=1e-19)
+        assert calc_attr.r_comb_inner_iw == approx(0.003819709702062643,
+                                                   abs=1e-19)
+        assert calc_attr.alpha_conv_inner_iw == approx(2.7, abs=0.1)
+        assert calc_attr.alpha_rad_inner_iw == approx(5.0, abs=0.1)
+        assert calc_attr.alpha_comb_inner_iw == approx(7.7, abs=0.1)
 
         # outerwall
-        assert round(calc_attr.ua_value_ow, 16) == 19.83577523748189
-        assert round(calc_attr.area_ow, 1) == 48.0
-        assert round(calc_attr.r_conv_inner_ow, 19) == 0.007716049382716048
-        assert round(calc_attr.r_rad_inner_ow, 18) == 0.004166666666666667
-        assert round(calc_attr.r_comb_inner_ow, 20) == 0.0027056277056277055
-        assert round(calc_attr.r_conv_outer_ow, 20) == 0.0010416666666666667
-        assert round(calc_attr.r_rad_outer_ow, 18) == 0.004166666666666667
-        assert round(calc_attr.r_comb_outer_ow, 20) == 0.0008333333333333334
-        assert round(calc_attr.alpha_conv_inner_ow, 5) == 2.7
-        assert round(calc_attr.alpha_rad_inner_ow, 5) == 5.0
-        assert round(calc_attr.alpha_comb_inner_ow, 5) == 7.7
-        assert round(calc_attr.alpha_conv_outer_ow, 1) == 20.0
-        assert round(calc_attr.alpha_rad_outer_ow, 5) == 5.0
-        assert round(calc_attr.alpha_comb_outer_ow, 1) == 25.0
+        assert calc_attr.ua_value_ow == approx(19.83577523748189, abs=1e-14)
+        assert calc_attr.area_ow == approx(48.0, abs=0.1)
+        assert calc_attr.r_conv_inner_ow == approx(0.007716049382716048,
+                                                   abs=1e-19)
+        assert calc_attr.r_rad_inner_ow == approx(0.004166666666666667,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_inner_ow == approx(0.0027056277056277055,
+                                                   abs=1e-20)
+        assert calc_attr.r_conv_outer_ow == approx(0.0010416666666666667,
+                                                   abs=1e-20)
+        assert calc_attr.r_rad_outer_ow == approx(0.004166666666666667,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_outer_ow == approx(0.0008333333333333334,
+                                                   abs=1e-20)
+        assert calc_attr.alpha_conv_inner_ow == approx(2.7, abs=0.00001)
+        assert calc_attr.alpha_rad_inner_ow == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_inner_ow == approx(7.7, abs=0.00001)
+        assert calc_attr.alpha_conv_outer_ow == approx(20.0, abs=0.1)
+        assert calc_attr.alpha_rad_outer_ow == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_outer_ow == approx(25.0, abs=0.1)
 
         # groundfloor
-        assert round(calc_attr.ua_value_gf, 16) == 58.351477449455686
-        assert round(calc_attr.area_gf, 1) == 140.0
-        assert round(calc_attr.r_conv_inner_gf, 19) == 0.004201680672268907
-        assert round(calc_attr.r_rad_inner_gf, 18) == 0.001428571428571429
-        assert round(calc_attr.r_comb_inner_gf, 20) == 0.0010660980810234541
-        assert round(calc_attr.alpha_conv_inner_gf, 5) == 1.7
-        assert round(calc_attr.alpha_rad_inner_gf, 5) == 5.0
-        assert round(calc_attr.alpha_comb_inner_gf, 5) == 6.7
+        assert calc_attr.ua_value_gf == approx(58.351477449455686, abs=1e-14)
+        assert calc_attr.area_gf == approx(140.0, abs=0.1)
+        assert calc_attr.r_conv_inner_gf == approx(0.004201680672268907,
+                                                   abs=1e-19)
+        assert calc_attr.r_rad_inner_gf == approx(0.001428571428571429,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_inner_gf == approx(0.0010660980810234541,
+                                                   abs=1e-20)
+        assert calc_attr.alpha_conv_inner_gf == approx(1.7, abs=0.00001)
+        assert calc_attr.alpha_rad_inner_gf == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_inner_gf == approx(6.7, abs=0.00001)
 
-        # outerwall
-        assert round(calc_attr.ua_value_rt, 16) == 57.394603194028036
-        assert round(calc_attr.area_rt, 1) == 140.0
-        assert round(calc_attr.r_conv_inner_rt, 19) == 0.004201680672268907
-        assert round(calc_attr.r_rad_inner_rt, 18) == 0.001428571428571429
-        assert round(calc_attr.r_comb_inner_rt, 20) == 0.0010660980810234541
-        assert round(calc_attr.r_conv_outer_rt, 20) == 0.00035714285714285714
-        assert round(calc_attr.r_rad_outer_rt, 18) == 0.001428571428571429
-        assert round(calc_attr.r_comb_outer_rt, 20) == 0.00028571428571428574
-        assert round(calc_attr.alpha_conv_inner_rt, 5) == 1.7
-        assert round(calc_attr.alpha_rad_inner_rt, 5) == 5.0
-        assert round(calc_attr.alpha_comb_inner_rt, 5) == 6.7
-        assert round(calc_attr.alpha_conv_outer_rt, 1) == 20.0
-        assert round(calc_attr.alpha_rad_outer_rt, 5) == 5.0
-        assert round(calc_attr.alpha_comb_outer_rt, 1) == 25.0
+        # roof/top (rt)
+        assert calc_attr.ua_value_rt == approx(57.394603194028036, abs=1e-14)
+        assert calc_attr.area_rt == approx(140.0, abs=0.1)
+        assert calc_attr.r_conv_inner_rt == approx(0.004201680672268907,
+                                                   abs=1e-19)
+        assert calc_attr.r_rad_inner_rt == approx(0.001428571428571429,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_inner_rt == approx(0.0010660980810234541,
+                                                   abs=1e-20)
+        assert calc_attr.r_conv_outer_rt == approx(0.00035714285714285714,
+                                                   abs=1e-20)
+        assert calc_attr.r_rad_outer_rt == approx(0.001428571428571429,
+                                                  abs=1e-18)
+        assert calc_attr.r_comb_outer_rt == approx(0.00028571428571428574,
+                                                   abs=1e-20)
+        assert calc_attr.alpha_conv_inner_rt == approx(1.7, abs=0.00001)
+        assert calc_attr.alpha_rad_inner_rt == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_inner_rt == approx(6.7, abs=0.00001)
+        assert calc_attr.alpha_conv_outer_rt == approx(20.0, abs=0.1)
+        assert calc_attr.alpha_rad_outer_rt == approx(5.0, abs=0.00001)
+        assert calc_attr.alpha_comb_outer_rt == approx(25.0, abs=0.1)
 
         # window
-        assert round(calc_attr.ua_value_win, 16) == 32.87895310796074
-        assert round(calc_attr.area_win, 1) == 18.0
-        assert round(calc_attr.r_conv_inner_win, 19) == 0.032679738562091505
-        assert round(calc_attr.r_rad_inner_win, 4) == 0.0111
-        assert round(calc_attr.r_comb_inner_win, 19) == 0.008291873963515755
-        assert round(calc_attr.r_conv_outer_win, 5) == 0.00278
-        assert round(calc_attr.r_rad_outer_win, 4) == 0.0111
-        assert round(calc_attr.r_comb_outer_win, 4) == 0.0022
-        assert round(calc_attr.alpha_conv_inner_win, 1) == 1.7
-        assert round(calc_attr.alpha_comb_outer_win, 1) == 25.0
-        assert round(calc_attr.alpha_conv_outer_win, 1) == 20.0
-        assert round(calc_attr.weighted_g_value, 3) == 0.789
+        assert calc_attr.ua_value_win == approx(32.87895310796074, abs=1e-14)
+        assert calc_attr.area_win == approx(18.0, abs=0.1)
+        assert calc_attr.r_conv_inner_win == approx(0.032679738562091505,
+                                                    abs=1e-19)
+        assert calc_attr.r_rad_inner_win == approx(0.0111, abs=0.0001)
+        assert calc_attr.r_comb_inner_win == approx(0.008291873963515755,
+                                                    abs=1e-19)
+        assert calc_attr.r_conv_outer_win == approx(0.00278, abs=0.00001)
+        assert calc_attr.r_rad_outer_win == approx(0.0111, abs=0.0001)
+        assert calc_attr.r_comb_outer_win == approx(0.0022, abs=0.0001)
+        assert calc_attr.alpha_conv_inner_win == approx(1.7, abs=0.1)
+        assert calc_attr.alpha_comb_outer_win == approx(25.0, abs=0.1)
+        assert calc_attr.alpha_conv_outer_win == approx(20.0, abs=0.1)
+        assert calc_attr.weighted_g_value == approx(0.789, abs=0.001)
 
     def test_calc_chain_matrix_four(self):
         """test of calc_chain_matrix"""


### PR DESCRIPTION
This should solve a current problem where python 3.12. pipelines fail due to some changes in python 3.12. handling floating point calculations.