### PR TITLE
Fix broken links for related work in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ The workflow for changes is described in our [Wiki](https://github.com/RWTH-EBC/
 
 + TEASER: an open tool for urban energy modelling of building stocks. Remmen P., Lauster M., Mans M., Fuchs M., Osterhage T., Müller D.. Journal of Building Performance Simulation, February 2017,
 [pdf](http://dx.doi.org/10.1080/19401493.2017.1283539),
-[bibtex](https://github.com/RWTH-EBC/TEASER/tree/main/doc/cite_jbps.bib)
+[bibtex](https://github.com/RWTH-EBC/TEASER/tree/main/docs/source/cite_jbps.bib)
 
 ### TEASER related publications
 
 + CityGML Import and Export for Dynamic Building Performance Simulation in Modelica. Remmen P.,
 Lauster M., Mans M., Osterhage T., Müller D.. BSO16, p.329-336, September 2016,
-[pdf](http://www.ibpsa.org/proceedings/BSO2016/p1047.pdf),
-[bibtex](https://github.com/RWTH-EBC/TEASER/tree/main/doc/cite.bib)
+[pdf](https://publications.ibpsa.org/conference/paper/?id=bso2016_1047),
+[bibtex](https://github.com/RWTH-EBC/TEASER/tree/main/docs/source/cite.bib)
 
 + Scalable Design-Driven Parameterization of Reduced Order Models Using Archetype Buildings with TEASER.
 Lauster M., Mans M., Remmen P., Fuchs M., Müller D.. BauSIM2016, p.535-542, September 2016,
@@ -123,7 +123,7 @@ Lauster M., Mans M., Remmen P., Fuchs M., Müller D.. BauSIM2016, p.535-542, Sep
 Remmen P., Schäfer J., Müller D.. Building Simulation 2019, September 2019,
 [pdf](https://www.researchgate.net/publication/337925776_Refinement_of_Dynamic_Non-Residential_Building_Archetypes_Using_Measurement_Data_and_Bayesian_Calibration)
 
-+ Selecting statistical indices for calibrating building energy models. Vogt, M., Remmen P., Lauster M., Fuchs M. , Müller D.. Building and Environment 144, pages 94-107, October 2018. [bibtex](https://github.com/RWTH-EBC/TEASER/tree/main/doc/cite_be.bib)
++ Selecting statistical indices for calibrating building energy models. Vogt, M., Remmen P., Lauster M., Fuchs M. , Müller D.. Building and Environment 144, pages 94-107, October 2018. [bibtex](https://github.com/RWTH-EBC/TEASER/tree/main/docs/source/cite_be.bib)
 
 + The [Institute of Energy Efficiency and Sustainable Building](https://www.e3d.rwth-aachen.de/go/id/iyld/?) published a parametric study of TEASER where all functions and  parameters used in TEASER are gathered and explained. The publication can be found [here](https://publications.rwth-aachen.de/record/749801/files/749801.pdf).
 


### PR DESCRIPTION
# Description

Some links in the "TEASER related publications" section of the README are broken. 
This PR fixes the ones I discovered.

# Changes
* All bibtex links have been broken since 268f6edca3629452243611395789f8d2bb1e1f62. The correct source tree path is `/docs/source/`, not `/doc/`
* The CityGML paper has been moved. Since it lacks a DOI, we update the URL.
